### PR TITLE
Slackアクションのリマインダーを一時停止する機能のテストを追加。次の営業日の朝の時間を取得する関数を実装し、関連するテストケースを作成。

### DIFF
--- a/handlers/slack_test.go
+++ b/handlers/slack_test.go
@@ -1,0 +1,238 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slack-review-notify/models"
+	"slack-review-notify/services"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleSlackAction_PauseReminder_Today(t *testing.T) {
+	// テスト用のDBとルーターをセットアップ
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/slack/action", HandleSlackAction(db))
+
+	// テスト用のタスクを作成
+	task := models.ReviewTask{
+		ID:           "test-task-id",
+		PRURL:        "https://github.com/owner/repo/pull/1",
+		Repo:         "owner/repo",
+		PRNumber:     1,
+		Title:        "Test PR",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewer:     "U12345",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	// テスト前の時刻を記録
+	beforeUpdate := time.Now()
+
+	// Slackアクションペイロードを作成
+	payload := SlackActionPayload{
+		Type: "block_actions",
+		User: struct {
+			ID string `json:"id"`
+		}{ID: "U12345"},
+		Actions: []struct {
+			ActionID string `json:"action_id"`
+			Value    string `json:"value,omitempty"`
+			SelectedOption struct {
+				Value string `json:"value"`
+				Text  struct {
+					Text string `json:"text"`
+				} `json:"text"`
+			} `json:"selected_option,omitempty"`
+		}{
+			{
+				ActionID: "pause_reminder",
+				SelectedOption: struct {
+					Value string `json:"value"`
+					Text  struct {
+						Text string `json:"text"`
+					} `json:"text"`
+				}{
+					Value: "test-task-id:today",
+					Text: struct {
+						Text string `json:"text"`
+					}{
+						Text: "翌営業日の朝まで",
+					},
+				},
+			},
+		},
+		Container: struct {
+			ChannelID string `json:"channel_id"`
+		}{ChannelID: "C12345"},
+		Message: struct {
+			Ts string `json:"ts"`
+		}{Ts: "1234.5678"},
+	}
+
+	payloadJSON, _ := json.Marshal(payload)
+	form := url.Values{}
+	form.Add("payload", string(payloadJSON))
+
+	// リクエストを作成
+	req := httptest.NewRequest("POST", "/slack/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// 署名の検証をモック（実際のテストでは適切に設定する必要があります）
+	services.IsTestMode = true
+	defer func() { services.IsTestMode = false }()
+
+	// リクエストを実行
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// レスポンスを確認
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// DBからタスクを取得して確認
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "test-task-id").First(&updatedTask)
+
+	// ReminderPausedUntilが設定されていることを確認
+	assert.NotNil(t, updatedTask.ReminderPausedUntil)
+
+	// 翌営業日の朝に設定されていることを確認
+	pausedUntil := *updatedTask.ReminderPausedUntil
+
+	// 現在時刻より後であることを確認
+	assert.True(t, pausedUntil.After(beforeUpdate))
+
+	// 10時に設定されていることを確認
+	assert.Equal(t, 10, pausedUntil.Hour())
+	assert.Equal(t, 0, pausedUntil.Minute())
+	assert.Equal(t, 0, pausedUntil.Second())
+
+	// 営業日（月〜金）であることを確認
+	assert.NotEqual(t, time.Saturday, pausedUntil.Weekday())
+	assert.NotEqual(t, time.Sunday, pausedUntil.Weekday())
+}
+
+func TestHandleSlackAction_PauseReminder_Hours(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		duration time.Duration
+	}{
+		{"1時間", "test-task-id:1h", 1 * time.Hour},
+		{"2時間", "test-task-id:2h", 2 * time.Hour},
+		{"4時間", "test-task-id:4h", 4 * time.Hour},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// テスト用のDBとルーターをセットアップ
+			db := setupTestDB(t)
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			router.POST("/slack/action", HandleSlackAction(db))
+
+			// テスト用のタスクを作成
+			task := models.ReviewTask{
+				ID:           "test-task-id",
+				PRURL:        "https://github.com/owner/repo/pull/1",
+				Repo:         "owner/repo",
+				PRNumber:     1,
+				Title:        "Test PR",
+				SlackTS:      "1234.5678",
+				SlackChannel: "C12345",
+				Status:       "in_review",
+				Reviewer:     "U12345",
+				CreatedAt:    time.Now(),
+				UpdatedAt:    time.Now(),
+			}
+			db.Create(&task)
+
+			// テスト前の時刻を記録
+			beforeUpdate := time.Now()
+
+			// Slackアクションペイロードを作成
+			payload := SlackActionPayload{
+				Type: "block_actions",
+				User: struct {
+					ID string `json:"id"`
+				}{ID: "U12345"},
+				Actions: []struct {
+					ActionID string `json:"action_id"`
+					Value    string `json:"value,omitempty"`
+					SelectedOption struct {
+						Value string `json:"value"`
+						Text  struct {
+							Text string `json:"text"`
+						} `json:"text"`
+					} `json:"selected_option,omitempty"`
+				}{
+					{
+						ActionID: "pause_reminder",
+						SelectedOption: struct {
+							Value string `json:"value"`
+							Text  struct {
+								Text string `json:"text"`
+							} `json:"text"`
+						}{
+							Value: tc.value,
+						},
+					},
+				},
+				Container: struct {
+					ChannelID string `json:"channel_id"`
+				}{ChannelID: "C12345"},
+				Message: struct {
+					Ts string `json:"ts"`
+				}{Ts: "1234.5678"},
+			}
+
+			payloadJSON, _ := json.Marshal(payload)
+			form := url.Values{}
+			form.Add("payload", string(payloadJSON))
+
+			// リクエストを作成
+			req := httptest.NewRequest("POST", "/slack/action", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			// 署名の検証をモック
+			services.IsTestMode = true
+			defer func() { services.IsTestMode = false }()
+
+			// リクエストを実行
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			// レスポンスを確認
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			// DBからタスクを取得して確認
+			var updatedTask models.ReviewTask
+			db.Where("id = ?", "test-task-id").First(&updatedTask)
+
+			// ReminderPausedUntilが設定されていることを確認
+			assert.NotNil(t, updatedTask.ReminderPausedUntil)
+
+			// 指定された時間だけ後に設定されていることを確認
+			pausedUntil := *updatedTask.ReminderPausedUntil
+			expectedTime := beforeUpdate.Add(tc.duration)
+
+			// 誤差を考慮して確認（1分以内の誤差を許容）
+			diff := pausedUntil.Sub(expectedTime)
+			assert.True(t, diff < time.Minute && diff > -time.Minute,
+				"Expected pause until around %v, but got %v (diff: %v)",
+				expectedTime, pausedUntil, diff)
+		})
+	}
+}

--- a/services/slack.go
+++ b/services/slack.go
@@ -553,20 +553,46 @@ func SendReviewerChangedMessage(task models.ReviewTask, oldReviewerID string) er
 
 // 翌営業日の朝（10:00）の時間を取得する関数
 func GetNextBusinessDayMorning() time.Time {
-	now := time.Now()
-	nextDay := now.AddDate(0, 0, 1) // まず翌日を取得
+	return GetNextBusinessDayMorningWithTime(time.Now())
+}
 
-	// 10:00に設定する
-	nextDayMorning := time.Date(nextDay.Year(), nextDay.Month(), nextDay.Day(), 10, 0, 0, 0, nextDay.Location())
+// 指定された時刻から翌営業日の朝（10:00）の時間を取得する関数
+func GetNextBusinessDayMorningWithTime(now time.Time) time.Time {
+	// 今日の10:00を作成
+	todayMorning := time.Date(now.Year(), now.Month(), now.Day(), 10, 0, 0, 0, now.Location())
 
-	// 土曜日の場合、月曜日にする（2日進める）
-	if nextDayMorning.Weekday() == time.Saturday {
-		nextDayMorning = nextDayMorning.AddDate(0, 0, 2)
+	// 現在の曜日と時刻を確認
+	weekday := now.Weekday()
+	
+	// 結果を格納する変数
+	var nextBusinessDayMorning time.Time
+
+	switch weekday {
+	case time.Monday, time.Tuesday, time.Wednesday, time.Thursday:
+		// 月〜木の場合
+		if now.Before(todayMorning) {
+			// 10:00前なら今日の10:00
+			nextBusinessDayMorning = todayMorning
+		} else {
+			// 10:00以降なら翌日の10:00
+			nextBusinessDayMorning = todayMorning.AddDate(0, 0, 1)
+		}
+	case time.Friday:
+		// 金曜日の場合
+		if now.Before(todayMorning) {
+			// 10:00前なら今日の10:00
+			nextBusinessDayMorning = todayMorning
+		} else {
+			// 10:00以降なら月曜日の10:00（3日後）
+			nextBusinessDayMorning = todayMorning.AddDate(0, 0, 3)
+		}
+	case time.Saturday:
+		// 土曜日の場合、月曜日の10:00（2日後）
+		nextBusinessDayMorning = todayMorning.AddDate(0, 0, 2)
+	case time.Sunday:
+		// 日曜日の場合、月曜日の10:00（1日後）
+		nextBusinessDayMorning = todayMorning.AddDate(0, 0, 1)
 	}
-	// 日曜日の場合、月曜日にする（1日進める）
-	if nextDayMorning.Weekday() == time.Sunday {
-		nextDayMorning = nextDayMorning.AddDate(0, 0, 1)
-	}
 
-	return nextDayMorning
+	return nextBusinessDayMorning
 }

--- a/services/slack_next_business_day_test.go
+++ b/services/slack_next_business_day_test.go
@@ -1,0 +1,131 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNextBusinessDayMorning_Detailed(t *testing.T) {
+	testCases := []struct {
+		name        string
+		currentTime time.Time
+		expected    time.Time
+	}{
+		{
+			name:        "月曜日の午前9時 → 月曜日の10時",
+			currentTime: time.Date(2024, 1, 8, 9, 0, 0, 0, time.Local), // 2024年1月8日は月曜日
+			expected:    time.Date(2024, 1, 8, 10, 0, 0, 0, time.Local),
+		},
+		{
+			name:        "月曜日の午後2時 → 火曜日の10時",
+			currentTime: time.Date(2024, 1, 8, 14, 0, 0, 0, time.Local),
+			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, time.Local),
+		},
+		{
+			name:        "金曜日の午後2時 → 月曜日の10時",
+			currentTime: time.Date(2024, 1, 12, 14, 0, 0, 0, time.Local), // 2024年1月12日は金曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+		},
+		{
+			name:        "土曜日の午後2時 → 月曜日の10時",
+			currentTime: time.Date(2024, 1, 13, 14, 0, 0, 0, time.Local), // 2024年1月13日は土曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+		},
+		{
+			name:        "日曜日の午後2時 → 月曜日の10時",
+			currentTime: time.Date(2024, 1, 14, 14, 0, 0, 0, time.Local), // 2024年1月14日は日曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+		},
+		{
+			name:        "木曜日の午後11時59分 → 金曜日の10時",
+			currentTime: time.Date(2024, 1, 11, 23, 59, 0, 0, time.Local), // 2024年1月11日は木曜日
+			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, time.Local),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// 時刻を固定するためのモック関数を作成
+			// 注: 現在の実装では time.Now() を使用しているため、
+			// このテストは現在の実装では失敗します
+			// 実際のテストのため、GetNextBusinessDayMorningに時刻を渡せるようにする必要があります
+			
+			// 現在の実装をテスト（バグがあることを確認）
+			result := GetNextBusinessDayMorning()
+			
+			// 現在の実装では常に「翌日」になるため、このテストは失敗するはずです
+			t.Logf("現在時刻: %s", tc.currentTime.Format("2006-01-02 15:04:05"))
+			t.Logf("期待値: %s", tc.expected.Format("2006-01-02 15:04:05"))
+			t.Logf("実際の値: %s", result.Format("2006-01-02 15:04:05"))
+		})
+	}
+}
+
+func TestGetNextBusinessDayMorningWithTime(t *testing.T) {
+	testCases := []struct {
+		name        string
+		currentTime time.Time
+		expected    time.Time
+	}{
+		{
+			name:        "月曜日の午前9時 → 月曜日の10時",
+			currentTime: time.Date(2024, 1, 8, 9, 0, 0, 0, time.Local), // 2024年1月8日は月曜日
+			expected:    time.Date(2024, 1, 8, 10, 0, 0, 0, time.Local),
+		},
+		{
+			name:        "月曜日の午前10時ちょうど → 火曜日の10時",
+			currentTime: time.Date(2024, 1, 8, 10, 0, 0, 0, time.Local),
+			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, time.Local),
+		},
+		{
+			name:        "月曜日の午前10時1分 → 火曜日の10時",
+			currentTime: time.Date(2024, 1, 8, 10, 1, 0, 0, time.Local),
+			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, time.Local),
+		},
+		{
+			name:        "月曜日の午後2時 → 火曜日の10時",
+			currentTime: time.Date(2024, 1, 8, 14, 0, 0, 0, time.Local),
+			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, time.Local),
+		},
+		{
+			name:        "金曜日の午前9時 → 金曜日の10時",
+			currentTime: time.Date(2024, 1, 12, 9, 0, 0, 0, time.Local), // 2024年1月12日は金曜日
+			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, time.Local),
+		},
+		{
+			name:        "金曜日の午後2時 → 月曜日の10時",
+			currentTime: time.Date(2024, 1, 12, 14, 0, 0, 0, time.Local),
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+		},
+		{
+			name:        "土曜日の午後2時 → 月曜日の10時",
+			currentTime: time.Date(2024, 1, 13, 14, 0, 0, 0, time.Local), // 2024年1月13日は土曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+		},
+		{
+			name:        "日曜日の午後2時 → 月曜日の10時",
+			currentTime: time.Date(2024, 1, 14, 14, 0, 0, 0, time.Local), // 2024年1月14日は日曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+		},
+		{
+			name:        "木曜日の午後11時59分 → 金曜日の10時",
+			currentTime: time.Date(2024, 1, 11, 23, 59, 0, 0, time.Local), // 2024年1月11日は木曜日
+			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, time.Local),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// GetNextBusinessDayMorningWithTimeをテスト（まだ実装されていない）
+			result := GetNextBusinessDayMorningWithTime(tc.currentTime)
+			
+			assert.Equal(t, tc.expected, result, 
+				"currentTime: %s, expected: %s, got: %s",
+				tc.currentTime.Format("2006-01-02 15:04:05"),
+				tc.expected.Format("2006-01-02 15:04:05"),
+				result.Format("2006-01-02 15:04:05"))
+		})
+	}
+}


### PR DESCRIPTION
Slackアクションのリマインダーを一時停止する機能のテストを追加。次の営業日の朝の時間を取得する関数を実装し、関連するテストケースを作成。