### PR TITLE
タスクのラベル名とチャンネルIDの両方でデータベースから取得する

### DIFF
--- a/services/tasks.go
+++ b/services/tasks.go
@@ -40,7 +40,13 @@ func CheckInReviewTasks(db *gorm.DB) {
 		var config models.ChannelConfig
 		var reminderInterval int = 30 // デフォルト値（30分）
 
-		if err := db.Where("slack_channel_id = ?", task.SlackChannel).First(&config).Error; err == nil {
+		// LabelNameも考慮して設定を取得
+		labelName := task.LabelName
+		if labelName == "" {
+			labelName = "needs-review" // デフォルトのラベル名
+		}
+
+		if err := db.Where("slack_channel_id = ? AND label_name = ?", task.SlackChannel, labelName).First(&config).Error; err == nil {
 			if config.ReviewerReminderInterval > 0 {
 				reminderInterval = config.ReviewerReminderInterval
 			}

--- a/services/tasks_test.go
+++ b/services/tasks_test.go
@@ -179,3 +179,144 @@ func TestCheckInReviewTasks(t *testing.T) {
 	// テスト成功とする（モックが正しく動作していればOK）
 	// 実際のタイムスタンプの比較は行わない
 }
+
+func TestCheckInReviewTasks_ReminderInterval(t *testing.T) {
+	db := setupTestDB(t)
+
+	// テスト用の環境変数を設定
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	// テスト用のチャンネル設定を複数作成
+	now := time.Now()
+	
+	// needs-reviewラベル用設定：60分間隔
+	config1 := models.ChannelConfig{
+		ID:                       "config1",
+		SlackChannelID:           "C12345",
+		LabelName:                "needs-review",
+		DefaultMentionID:         "U12345",
+		ReviewerReminderInterval: 60, // 60分
+		IsActive:                 true,
+		CreatedAt:                now,
+		UpdatedAt:                now,
+	}
+	db.Create(&config1)
+
+	// bugラベル用設定：15分間隔
+	config2 := models.ChannelConfig{
+		ID:                       "config2",
+		SlackChannelID:           "C12345",
+		LabelName:                "bug",
+		DefaultMentionID:         "U67890",
+		ReviewerReminderInterval: 15, // 15分
+		IsActive:                 true,
+		CreatedAt:                now,
+		UpdatedAt:                now,
+	}
+	db.Create(&config2)
+
+	// テスト用のタスクを作成
+	twoHoursAgo := now.Add(-2 * time.Hour)
+	twentyMinutesAgo := now.Add(-20 * time.Minute)
+
+	// needs-reviewラベルのタスク（60分間隔、2時間前更新 → リマインド送信される）
+	task1 := models.ReviewTask{
+		ID:           "task1",
+		PRURL:        "https://github.com/owner/repo/pull/1",
+		Repo:         "owner/repo",
+		PRNumber:     1,
+		Title:        "Test PR 1",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewer:     "U12345",
+		LabelName:    "needs-review",
+		CreatedAt:    twoHoursAgo,
+		UpdatedAt:    twoHoursAgo,
+	}
+	db.Create(&task1)
+
+	// bugラベルのタスク（15分間隔、20分前更新 → リマインド送信される）
+	task2 := models.ReviewTask{
+		ID:           "task2",
+		PRURL:        "https://github.com/owner/repo/pull/2",
+		Repo:         "owner/repo",
+		PRNumber:     2,
+		Title:        "Test PR 2",
+		SlackTS:      "1234.5679",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewer:     "U67890",
+		LabelName:    "bug",
+		CreatedAt:    twentyMinutesAgo,
+		UpdatedAt:    twentyMinutesAgo,
+	}
+	db.Create(&task2)
+
+	// needs-reviewラベルのタスク（60分間隔、20分前更新 → リマインド送信されない）
+	task3 := models.ReviewTask{
+		ID:           "task3",
+		PRURL:        "https://github.com/owner/repo/pull/3",
+		Repo:         "owner/repo",
+		PRNumber:     3,
+		Title:        "Test PR 3",
+		SlackTS:      "1234.5680",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewer:     "U12345",
+		LabelName:    "needs-review",
+		CreatedAt:    twentyMinutesAgo,
+		UpdatedAt:    twentyMinutesAgo,
+	}
+	db.Create(&task3)
+
+	// モックの設定
+	defer gock.Off()
+
+	// チャンネル情報取得のモック
+	gock.New("https://slack.com").
+		Get("/api/conversations.info").
+		MatchParam("channel", "C12345").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{
+			"ok": true,
+			"channel": map[string]interface{}{
+				"id":          "C12345",
+				"is_archived": false,
+			},
+		})
+
+	// メッセージ送信のモック
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{
+			"ok": true,
+		})
+
+	// 関数を実行前のタイムスタンプを記録
+	beforeExecution := now
+
+	// 関数を実行
+	CheckInReviewTasks(db)
+
+	// アサーション
+	var updatedTask1 models.ReviewTask
+	db.Where("id = ?", "task1").First(&updatedTask1)
+	// task1は60分間隔で2時間前なのでリマインド送信されるはず
+	assert.True(t, updatedTask1.UpdatedAt.After(beforeExecution), "task1 should be updated")
+
+	var updatedTask2 models.ReviewTask
+	db.Where("id = ?", "task2").First(&updatedTask2)
+	// task2は15分間隔で20分前なのでリマインド送信されるはず
+	assert.True(t, updatedTask2.UpdatedAt.After(beforeExecution), "task2 should be updated")
+
+	var updatedTask3 models.ReviewTask
+	db.Where("id = ?", "task3").First(&updatedTask3)
+	// task3は60分間隔で20分前なのでリマインド送信されないはず
+	assert.False(t, updatedTask3.UpdatedAt.After(beforeExecution), "task3 should not be updated")
+}


### PR DESCRIPTION
タスクのラベル名とチャンネルIDの両方で設定をデータベースから取得する.
これまで、チャンネルしか設定してなかったので、first()で弾いてきたがヒットしてしまっていた。
バグ修正