### PR TITLE
クオートで区切るように、ヘルプもユーザーファーストに

### DIFF
--- a/handlers/command_test.go
+++ b/handlers/command_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "通常のスペースなしラベル名",
+			input:    "needs-review set-mention @user",
+			expected: []string{"needs-review", "set-mention", "@user"},
+		},
+		{
+			name:     "ダブルクォートで囲まれたスペース付きラベル名",
+			input:    "\"needs review\" set-mention @user",
+			expected: []string{"needs review", "set-mention", "@user"},
+		},
+		{
+			name:     "シングルクォートで囲まれたスペース付きラベル名",
+			input:    "'security review' add-reviewer @security",
+			expected: []string{"security review", "add-reviewer", "@security"},
+		},
+		{
+			name:     "複数のスペース付きパラメータ",
+			input:    "\"needs review\" set-mention \"@team lead\"",
+			expected: []string{"needs review", "set-mention", "@team lead"},
+		},
+		{
+			name:     "異なるクォート文字の混在",
+			input:    "'label name' \"param value\" test",
+			expected: []string{"label name", "param value", "test"},
+		},
+		{
+			name:     "クォート内にクォート文字",
+			input:    "\"label's name\" 'param \"value\"' test",
+			expected: []string{"label's name", "param \"value\"", "test"},
+		},
+		{
+			name:     "空文字列",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "スペースのみ",
+			input:    "   ",
+			expected: nil,
+		},
+		{
+			name:     "単一の要素",
+			input:    "show",
+			expected: []string{"show"},
+		},
+		{
+			name:     "クォートが閉じられていない場合（ダブルクォート）",
+			input:    "\"needs review set-mention @user",
+			expected: []string{"needs review set-mention @user"},
+		},
+		{
+			name:     "クォートが閉じられていない場合（シングルクォート）",
+			input:    "'security review add-reviewer @security",
+			expected: []string{"security review add-reviewer @security"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseCommand(tt.input)
+			
+			// nilと空のスライスを同等として扱う
+			if tt.expected == nil && len(result) == 0 {
+				return
+			}
+			if len(tt.expected) == 0 && len(result) == 0 {
+				return
+			}
+			
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseCommand(%q) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/handlers/commands_test.go
+++ b/handlers/commands_test.go
@@ -60,9 +60,10 @@ func TestHandleSlackCommand_Help(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 	assert.Contains(t, w.Body.String(), "Review通知Bot設定コマンド")
 	assert.Contains(t, w.Body.String(), "複数ラベル設定の使い方")
-	assert.Contains(t, w.Body.String(), "異なるラベルごとに別々のメンション先")
-	assert.Contains(t, w.Body.String(), "このチャンネルで設定済みのすべてのラベルを一覧表示")
-	assert.Contains(t, w.Body.String(), "指定したラベルの詳細設定を表示")
+	assert.Contains(t, w.Body.String(), "初期設定（必須）")
+	assert.Contains(t, w.Body.String(), "この2つを設定しないと通知は送信されません")
+	assert.Contains(t, w.Body.String(), "このチャンネルの全ラベル設定を表示")
+	assert.Contains(t, w.Body.String(), "指定ラベルの詳細設定を表示")
 }
 
 func TestHandleSlackCommand_Show(t *testing.T) {


### PR DESCRIPTION
## 概要
Slackコマンドでスペースを含むラベル名（"needs review"など）を正しく処理できるようにクォート機能を追加し、ヘルプメッセージの可読性を大幅に改善しました。

### 変更内容
- **クォート対応パーサーの実装**: `parseCommand`関数を新規追加し、ダブル・シングルクォートによるスペース付き引数を正しく解析
- **コマンドパース処理の改善**: `strings.Fields(text)`を`parseCommand(text)`に変更し、スペース付きラベル名に対応
- **ヘルプメッセージの再構築**: 必須設定を強調表示し、コマンドをカテゴリ別に整理して視認性を向上
- **テストケースの追加**: `parseCommand`関数の動作を検証する包括的なテストを追加
- **既存テストの修正**: 新しいヘルプメッセージに合わせてテスト内容を更新

### 期待すること
- ユーザーが"needs review"などのスペース付きラベル名を使用できるようになる
- 必須設定（メンション先・リポジトリ追加）が明確になり、設定ミスが減る
- ヘルプメッセージの構造化により、初心者でも設定手順が理解しやすくなる
- クォート処理のロバスト性により、様々な入力パターンに対応できる
