### PR TITLE
レビュー完了通知でGitHubスクリーンネーム表示対応

### DIFF
--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -242,7 +242,7 @@ func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 	// 各タスクについて完了通知を送信
 	for _, task := range tasks {
 		// レビュー完了通知をスレッドに投稿
-		if err := services.SendReviewCompletedAutoNotification(task, review.GetUser().GetLogin(), reviewState); err != nil {
+		if err := services.SendReviewCompletedAutoNotification(task, review.GetUser(), reviewState); err != nil {
 			log.Printf("failed to send review completed notification: %v", err)
 			// チャンネル関連のエラー（アーカイブ済み、権限なしなど）の場合はタスクを完了にする
 			if !services.IsChannelRelatedError(err) {

--- a/services/slack.go
+++ b/services/slack.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-github/v71/github"
+
 	"github.com/slack-go/slack"
 	"gorm.io/gorm"
 )
@@ -758,23 +760,24 @@ func UpdateSlackMessageForCompletedTask(task models.ReviewTask) error {
 }
 
 // レビュー完了の自動通知を送信する関数
-func SendReviewCompletedAutoNotification(task models.ReviewTask, reviewerLogin string, reviewState string) error {
+func SendReviewCompletedAutoNotification(task models.ReviewTask, reviewer *github.User, reviewState string) error {
+	displayName := GetDisplayName(reviewer)
 	var message string
 	var emoji string
 
 	switch reviewState {
 	case "approved":
 		emoji = "✅"
-		message = fmt.Sprintf("%s %sさんがレビューを承認しました！感謝！👏", emoji, reviewerLogin)
+		message = fmt.Sprintf("%s %sさんがレビューを承認しました！感謝！👏", emoji, displayName)
 	case "changes_requested":
 		emoji = "🔄"
-		message = fmt.Sprintf("%s %sさんが変更を要求しました 感謝！👏", emoji, reviewerLogin)
+		message = fmt.Sprintf("%s %sさんが変更を要求しました 感謝！👏", emoji, displayName)
 	case "commented":
 		emoji = "💬"
-		message = fmt.Sprintf("%s %sさんがレビューコメントを残しました 感謝！👏", emoji, reviewerLogin)
+		message = fmt.Sprintf("%s %sさんがレビューコメントを残しました 感謝！👏", emoji, displayName)
 	default:
 		emoji = "👀"
-		message = fmt.Sprintf("%s %sさんがレビューしました 感謝！👏", emoji, reviewerLogin)
+		message = fmt.Sprintf("%s %sさんがレビューしました 感謝！👏", emoji, displayName)
 	}
 
 	return PostToThread(task.SlackChannel, task.SlackTS, message)

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-github/v71/github"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 )
@@ -599,14 +600,34 @@ func TestSendReviewCompletedAutoNotification(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		reviewerLogin string
+		reviewerUser *github.User
 		reviewState  string
 		expectedMsg  string
 	}{
-		{"承認", "reviewer1", "approved", "✅ reviewer1さんがレビューを承認しました！感謝！👏"},
-		{"変更要求", "reviewer2", "changes_requested", "🔄 reviewer2さんが変更を要求しました 感謝！👏"},
-		{"コメント", "reviewer3", "commented", "💬 reviewer3さんがレビューコメントを残しました 感謝！👏"},
-		{"その他", "reviewer4", "other", "👀 reviewer4さんがレビューしました 感謝！👏"},
+		{
+			"承認 - display nameありの場合",
+			&github.User{Login: github.Ptr("reviewer1"), Name: github.Ptr("Test Reviewer 1")},
+			"approved",
+			"✅ Test Reviewer 1さんがレビューを承認しました！感謝！👏",
+		},
+		{
+			"変更要求 - display nameなしの場合",
+			&github.User{Login: github.Ptr("reviewer2"), Name: nil},
+			"changes_requested",
+			"🔄 reviewer2さんが変更を要求しました 感謝！👏",
+		},
+		{
+			"コメント - 空のdisplay nameの場合",
+			&github.User{Login: github.Ptr("reviewer3"), Name: github.Ptr("")},
+			"commented",
+			"💬 reviewer3さんがレビューコメントを残しました 感謝！👏",
+		},
+		{
+			"その他 - display nameありの場合",
+			&github.User{Login: github.Ptr("reviewer4"), Name: github.Ptr("Test Reviewer 4")},
+			"other",
+			"👀 Test Reviewer 4さんがレビューしました 感謝！👏",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -629,7 +650,7 @@ func TestSendReviewCompletedAutoNotification(t *testing.T) {
 			}
 
 			// 関数を実行
-			err := SendReviewCompletedAutoNotification(task, tc.reviewerLogin, tc.reviewState)
+			err := SendReviewCompletedAutoNotification(task, tc.reviewerUser, tc.reviewState)
 
 			// アサーション
 			assert.NoError(t, err)

--- a/services/user_display.go
+++ b/services/user_display.go
@@ -1,0 +1,25 @@
+package services
+
+import "github.com/google/go-github/v71/github"
+
+// GetDisplayName は GitHub User から表示名を取得する
+// Name フィールドが設定されている場合は Name を返し、
+// そうでなければ Login を返す
+func GetDisplayName(user *github.User) string {
+	if user == nil {
+		return ""
+	}
+	
+	// Name フィールドが設定されていて、空文字でない場合はそれを使用
+	if user.Name != nil && *user.Name != "" {
+		return *user.Name
+	}
+	
+	// Name が設定されていない、または空文字の場合は Login を使用
+	if user.Login != nil {
+		return *user.Login
+	}
+	
+	// すべて nil の場合は空文字を返す
+	return ""
+}

--- a/services/user_display_test.go
+++ b/services/user_display_test.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v71/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDisplayName(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     *github.User
+		expected string
+	}{
+		{
+			name: "Name が設定されている場合は Name を返す",
+			user: &github.User{
+				Login: github.Ptr("testuser"),
+				Name:  github.Ptr("Test User"),
+			},
+			expected: "Test User",
+		},
+		{
+			name: "Name が空文字の場合は Login を返す",
+			user: &github.User{
+				Login: github.Ptr("testuser"),
+				Name:  github.Ptr(""),
+			},
+			expected: "testuser",
+		},
+		{
+			name: "Name が nil の場合は Login を返す",
+			user: &github.User{
+				Login: github.Ptr("testuser"),
+				Name:  nil,
+			},
+			expected: "testuser",
+		},
+		{
+			name: "Login も nil の場合は空文字を返す",
+			user: &github.User{
+				Login: nil,
+				Name:  nil,
+			},
+			expected: "",
+		},
+		{
+			name: "user が nil の場合は空文字を返す",
+			user: nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetDisplayName(tt.user)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## 概要
GitHubのレビュー完了通知において、ユーザーID（login名）ではなくGitHubのスクリーンネーム（display name）を表示するように改善しました。GitHub APIトークンを使わず、Webhook payloadから直接取得する軽量な実装です。

### 変更内容
- **新機能追加**: `GetDisplayName`関数でGitHub UserからdisplayNameまたはloginを適切に選択
- **関数シグネチャ変更**: `SendReviewCompletedAutoNotification`が`*github.User`オブジェクトを受け取るように変更
- **Webhookハンドラー更新**: レビュー完了通知で新しい関数を使用
- **テスト追加**: display nameの各種パターン（あり/なし/空）をカバーするテストを追加
- **後方互換性**: 旧関数を削除してコードをクリーンアップ

### 期待すること
- **ユーザー体験向上**: Slackでのレビュー通知がより分かりやすい表示名（実名）で表示される
- **保守性向上**: GitHub tokenが不要でシンプルな実装
- **堅牢性**: display nameが設定されていない場合も適切にlogin名でフォールバック
- **テストカバレッジ**: 各種ケースを網羅したテストで品質を保証
