### PR TITLE
翌営業日通知機能のタイムゾーンがUTCだったのでJSTにする

### DIFF
--- a/services/slack.go
+++ b/services/slack.go
@@ -669,11 +669,21 @@ func GetNextBusinessDayMorning() time.Time {
 
 // 指定された時刻から翌営業日の朝（10:00）の時間を取得する関数
 func GetNextBusinessDayMorningWithTime(now time.Time) time.Time {
-	// 今日の10:00を作成
-	todayMorning := time.Date(now.Year(), now.Month(), now.Day(), 10, 0, 0, 0, now.Location())
+	// JST タイムゾーンを取得
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		// フォールバック：現在のタイムゾーンを使用
+		jst = now.Location()
+	}
 
-	// 現在の曜日と時刻を確認
-	weekday := now.Weekday()
+	// 現在時刻をJSTに変換
+	nowInJST := now.In(jst)
+	
+	// 今日の10:00（JST）を作成
+	todayMorning := time.Date(nowInJST.Year(), nowInJST.Month(), nowInJST.Day(), 10, 0, 0, 0, jst)
+
+	// 現在の曜日と時刻を確認（JST基準）
+	weekday := nowInJST.Weekday()
 	
 	// 結果を格納する変数
 	var nextBusinessDayMorning time.Time
@@ -681,7 +691,7 @@ func GetNextBusinessDayMorningWithTime(now time.Time) time.Time {
 	switch weekday {
 	case time.Monday, time.Tuesday, time.Wednesday, time.Thursday:
 		// 月〜木の場合
-		if now.Before(todayMorning) {
+		if nowInJST.Before(todayMorning) {
 			// 10:00前なら今日の10:00
 			nextBusinessDayMorning = todayMorning
 		} else {
@@ -690,7 +700,7 @@ func GetNextBusinessDayMorningWithTime(now time.Time) time.Time {
 		}
 	case time.Friday:
 		// 金曜日の場合
-		if now.Before(todayMorning) {
+		if nowInJST.Before(todayMorning) {
 			// 10:00前なら今日の10:00
 			nextBusinessDayMorning = todayMorning
 		} else {

--- a/services/slack_next_business_day_test.go
+++ b/services/slack_next_business_day_test.go
@@ -8,6 +8,10 @@ import (
 )
 
 func TestGetNextBusinessDayMorning_Detailed(t *testing.T) {
+	// JST タイムゾーンを取得
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+
 	testCases := []struct {
 		name        string
 		currentTime time.Time
@@ -15,33 +19,33 @@ func TestGetNextBusinessDayMorning_Detailed(t *testing.T) {
 	}{
 		{
 			name:        "月曜日の午前9時 → 月曜日の10時",
-			currentTime: time.Date(2024, 1, 8, 9, 0, 0, 0, time.Local), // 2024年1月8日は月曜日
-			expected:    time.Date(2024, 1, 8, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 8, 9, 0, 0, 0, jst), // 2024年1月8日は月曜日
+			expected:    time.Date(2024, 1, 8, 10, 0, 0, 0, jst),
 		},
 		{
 			name:        "月曜日の午後2時 → 火曜日の10時",
-			currentTime: time.Date(2024, 1, 8, 14, 0, 0, 0, time.Local),
-			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 8, 14, 0, 0, 0, jst),
+			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, jst),
 		},
 		{
 			name:        "金曜日の午後2時 → 月曜日の10時",
-			currentTime: time.Date(2024, 1, 12, 14, 0, 0, 0, time.Local), // 2024年1月12日は金曜日
-			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+			currentTime: time.Date(2024, 1, 12, 14, 0, 0, 0, jst), // 2024年1月12日は金曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, jst), // 2024年1月15日は月曜日
 		},
 		{
 			name:        "土曜日の午後2時 → 月曜日の10時",
-			currentTime: time.Date(2024, 1, 13, 14, 0, 0, 0, time.Local), // 2024年1月13日は土曜日
-			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+			currentTime: time.Date(2024, 1, 13, 14, 0, 0, 0, jst), // 2024年1月13日は土曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, jst), // 2024年1月15日は月曜日
 		},
 		{
 			name:        "日曜日の午後2時 → 月曜日の10時",
-			currentTime: time.Date(2024, 1, 14, 14, 0, 0, 0, time.Local), // 2024年1月14日は日曜日
-			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+			currentTime: time.Date(2024, 1, 14, 14, 0, 0, 0, jst), // 2024年1月14日は日曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, jst), // 2024年1月15日は月曜日
 		},
 		{
 			name:        "木曜日の午後11時59分 → 金曜日の10時",
-			currentTime: time.Date(2024, 1, 11, 23, 59, 0, 0, time.Local), // 2024年1月11日は木曜日
-			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 11, 23, 59, 0, 0, jst), // 2024年1月11日は木曜日
+			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, jst),
 		},
 	}
 
@@ -64,6 +68,10 @@ func TestGetNextBusinessDayMorning_Detailed(t *testing.T) {
 }
 
 func TestGetNextBusinessDayMorningWithTime(t *testing.T) {
+	// JST タイムゾーンを取得
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+
 	testCases := []struct {
 		name        string
 		currentTime time.Time
@@ -71,48 +79,48 @@ func TestGetNextBusinessDayMorningWithTime(t *testing.T) {
 	}{
 		{
 			name:        "月曜日の午前9時 → 月曜日の10時",
-			currentTime: time.Date(2024, 1, 8, 9, 0, 0, 0, time.Local), // 2024年1月8日は月曜日
-			expected:    time.Date(2024, 1, 8, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 8, 9, 0, 0, 0, jst), // 2024年1月8日は月曜日
+			expected:    time.Date(2024, 1, 8, 10, 0, 0, 0, jst),
 		},
 		{
 			name:        "月曜日の午前10時ちょうど → 火曜日の10時",
-			currentTime: time.Date(2024, 1, 8, 10, 0, 0, 0, time.Local),
-			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 8, 10, 0, 0, 0, jst),
+			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, jst),
 		},
 		{
 			name:        "月曜日の午前10時1分 → 火曜日の10時",
-			currentTime: time.Date(2024, 1, 8, 10, 1, 0, 0, time.Local),
-			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 8, 10, 1, 0, 0, jst),
+			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, jst),
 		},
 		{
 			name:        "月曜日の午後2時 → 火曜日の10時",
-			currentTime: time.Date(2024, 1, 8, 14, 0, 0, 0, time.Local),
-			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 8, 14, 0, 0, 0, jst),
+			expected:    time.Date(2024, 1, 9, 10, 0, 0, 0, jst),
 		},
 		{
 			name:        "金曜日の午前9時 → 金曜日の10時",
-			currentTime: time.Date(2024, 1, 12, 9, 0, 0, 0, time.Local), // 2024年1月12日は金曜日
-			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 12, 9, 0, 0, 0, jst), // 2024年1月12日は金曜日
+			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, jst),
 		},
 		{
 			name:        "金曜日の午後2時 → 月曜日の10時",
-			currentTime: time.Date(2024, 1, 12, 14, 0, 0, 0, time.Local),
-			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+			currentTime: time.Date(2024, 1, 12, 14, 0, 0, 0, jst),
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, jst), // 2024年1月15日は月曜日
 		},
 		{
 			name:        "土曜日の午後2時 → 月曜日の10時",
-			currentTime: time.Date(2024, 1, 13, 14, 0, 0, 0, time.Local), // 2024年1月13日は土曜日
-			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+			currentTime: time.Date(2024, 1, 13, 14, 0, 0, 0, jst), // 2024年1月13日は土曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, jst), // 2024年1月15日は月曜日
 		},
 		{
 			name:        "日曜日の午後2時 → 月曜日の10時",
-			currentTime: time.Date(2024, 1, 14, 14, 0, 0, 0, time.Local), // 2024年1月14日は日曜日
-			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, time.Local), // 2024年1月15日は月曜日
+			currentTime: time.Date(2024, 1, 14, 14, 0, 0, 0, jst), // 2024年1月14日は日曜日
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, jst), // 2024年1月15日は月曜日
 		},
 		{
 			name:        "木曜日の午後11時59分 → 金曜日の10時",
-			currentTime: time.Date(2024, 1, 11, 23, 59, 0, 0, time.Local), // 2024年1月11日は木曜日
-			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, time.Local),
+			currentTime: time.Date(2024, 1, 11, 23, 59, 0, 0, jst), // 2024年1月11日は木曜日
+			expected:    time.Date(2024, 1, 12, 10, 0, 0, 0, jst),
 		},
 	}
 

--- a/services/tasks_timezone_test.go
+++ b/services/tasks_timezone_test.go
@@ -1,0 +1,156 @@
+package services
+
+import (
+	"slack-review-notify/models"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckInReviewTasks_ReminderPausedUntilTimezone(t *testing.T) {
+	db := setupTestDB(t)
+
+	// JST タイムゾーン設定
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+
+	// テスト時刻（JST）：火曜日の13:00
+	baseTimeJST := time.Date(2024, 8, 27, 13, 0, 0, 0, jst)
+	
+	// 翌営業日の朝（JST 10:00）を計算
+	nextBusinessDayJST := GetNextBusinessDayMorningWithTime(baseTimeJST)
+	
+	// UTC での同じ時刻
+	baseTimeUTC := baseTimeJST.UTC()
+	nextBusinessDayUTC := nextBusinessDayJST.UTC()
+
+	tests := []struct {
+		name          string
+		currentTime   time.Time // テスト実行時の現在時刻
+		pausedUntil   *time.Time // reminder_paused_until の値（データベース保存値）
+		shouldSkip    bool       // リマインダーがスキップされるべきか
+		description   string
+	}{
+		{
+			name:        "JST_with_JST_paused_until",
+			currentTime: baseTimeJST,
+			pausedUntil: &nextBusinessDayJST,
+			shouldSkip:  true,
+			description: "JST現在時刻、JST一時停止時刻 - スキップされる",
+		},
+		{
+			name:        "UTC_with_UTC_paused_until",
+			currentTime: baseTimeUTC,
+			pausedUntil: &nextBusinessDayUTC,
+			shouldSkip:  true,
+			description: "UTC現在時刻、UTC一時停止時刻 - スキップされる",
+		},
+		{
+			name:        "JST_with_UTC_paused_until",
+			currentTime: baseTimeJST,
+			pausedUntil: &nextBusinessDayUTC, // データベース保存値（UTC）
+			shouldSkip:  true,
+			description: "JST現在時刻、UTC一時停止時刻（実際のケース） - スキップされる",
+		},
+		{
+			name:        "past_paused_until",
+			currentTime: baseTimeJST,
+			pausedUntil: func() *time.Time { t := baseTimeJST.Add(-1 * time.Hour); return &t }(), // 1時間前
+			shouldSkip:  false,
+			description: "過去の一時停止時刻 - スキップされない",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// テストタスクを作成
+			task := models.ReviewTask{
+				ID:                    tt.name + "_task",
+				PRURL:                 "https://github.com/owner/repo/pull/1",
+				Repo:                  "owner/repo",
+				PRNumber:              1,
+				Title:                 "Test PR",
+				SlackTS:               "1234.5678",
+				SlackChannel:          "C12345",
+				Status:                "in_review",
+				Reviewer:              "U12345",
+				LabelName:             "needs-review",
+				ReminderPausedUntil:   tt.pausedUntil,
+				CreatedAt:             tt.currentTime.Add(-2 * time.Hour),
+				UpdatedAt:             tt.currentTime.Add(-2 * time.Hour), // 2時間前に更新（リマインド対象）
+			}
+
+			db.Create(&task)
+
+			// 現在時刻の比較ロジックをシミュレート
+			now := tt.currentTime
+			shouldSkip := task.ReminderPausedUntil != nil && now.Before(*task.ReminderPausedUntil)
+
+			assert.Equal(t, tt.shouldSkip, shouldSkip, "Test: %s - %s", tt.name, tt.description)
+
+			// クリーンアップ
+			db.Where("id = ?", task.ID).Delete(&models.ReviewTask{})
+		})
+	}
+}
+
+func TestGetNextBusinessDayMorning_Timezone(t *testing.T) {
+	// JST タイムゾーン設定
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		inputTime   time.Time
+		expectedDay int
+		expectedHour int
+		description string
+	}{
+		{
+			name:        "JST_Tuesday_15_00",
+			inputTime:   time.Date(2024, 8, 27, 15, 0, 0, 0, jst), // 火曜日 15:00 JST
+			expectedDay: 28, // 水曜日
+			expectedHour: 10,
+			description: "火曜日 15:00 JST -> 翌日（水曜日）10:00 JST",
+		},
+		{
+			name:        "UTC_equivalent_Tuesday_06_00",
+			inputTime:   time.Date(2024, 8, 27, 6, 0, 0, 0, time.UTC), // 火曜日 06:00 UTC = 火曜日 15:00 JST
+			expectedDay: 28, // 水曜日
+			expectedHour: 10,
+			description: "火曜日 06:00 UTC（= 火曜日 15:00 JST）-> 翌日（水曜日）10:00 JST",
+		},
+		{
+			name:        "JST_Tuesday_09_00",
+			inputTime:   time.Date(2024, 8, 27, 9, 0, 0, 0, jst), // 火曜日 09:00 JST
+			expectedDay: 27, // 火曜日（同日）
+			expectedHour: 10,
+			description: "火曜日 09:00 JST -> 当日（火曜日）10:00 JST",
+		},
+		{
+			name:        "UTC_equivalent_Tuesday_00_00",
+			inputTime:   time.Date(2024, 8, 27, 0, 0, 0, 0, time.UTC), // 火曜日 00:00 UTC = 火曜日 09:00 JST
+			expectedDay: 27, // 火曜日（同日）
+			expectedHour: 10,
+			description: "火曜日 00:00 UTC（= 火曜日 09:00 JST）-> 当日（火曜日）10:00 JST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 翌営業日を計算
+			nextBusinessDay := GetNextBusinessDayMorningWithTime(tt.inputTime)
+
+			// 結果は常に JST で指定された日の 10:00 になるはず
+			assert.Equal(t, 2024, nextBusinessDay.Year(), "Year should be 2024")
+			assert.Equal(t, time.August, nextBusinessDay.Month(), "Month should be August")
+			assert.Equal(t, tt.expectedDay, nextBusinessDay.Day(), "Day should match expected: %s", tt.description)
+			assert.Equal(t, tt.expectedHour, nextBusinessDay.Hour(), "Hour should be 10: %s", tt.description)
+			assert.Equal(t, 0, nextBusinessDay.Minute(), "Minute should be 0: %s", tt.description)
+			
+			// タイムゾーンはJSTであるべき
+			assert.Equal(t, jst.String(), nextBusinessDay.Location().String(), "Timezone should be JST: %s", tt.description)
+		})
+	}
+}


### PR DESCRIPTION
## 概要
「翌営業日の朝まで通知しない」機能において、タイムゾーンの不整合により意図された時刻に通知が再開されない問題を修正。UTC環境で動作するサーバーにおいて、営業時間の基準を明示的にJST（Asia/Tokyo）に設定することで、正しい営業日時判定を実現する。

### 変更内容
- `GetNextBusinessDayMorningWithTime`関数をJST基準での営業日計算に修正
  - 入力時刻のタイムゾーンに依存していた問題を解決
  - 明示的にAsia/Tokyoタイムゾーンを使用した営業開始時刻（10:00 JST）の計算
  - JST基準での曜日・時刻判定に変更
- 既存のテストケースをJST対応に更新
  - `time.Local`を`jst`（Asia/Tokyo）に変更
  - テスト関数内でのタイムゾーン設定を追加
- 新規テストケース追加
  - タイムゾーン変換の正確性を検証するテストケース
  - UTC⇔JSTの時刻変換における翌営業日計算の正確性テスト

### 期待すること
- 翌営業日通知機能が日本の営業時間（JST 10:00）に基づいて正確に動作する
- UTC環境で動作するサーバーにおいても、日本時間での営業日判定が正しく機能する
- リマインダー一時停止機能の時刻比較が正確に行われる
- 既存の営業日計算ロジックが引き続き正常に動作する
