### PR TITLE
Dockerfileにタイムゾーンデータ（tzdata）を追加し、SQLite実行に必要なライブラリを更新

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o slack-review-notify
 FROM alpine:latest
 
 # 必要なライブラリをインストール（SQLite実行に必要）
-RUN apk --no-cache add ca-certificates sqlite
+RUN apk --no-cache add ca-certificates sqlite tzdata
 
 WORKDIR /app
 


### PR DESCRIPTION
1. 本番環境のDockerイメージにtzdataが含まれていない
2. そのためtime.LoadLocation("Asia/Tokyo")が失敗
3. フォールバック処理でUTCタイムゾーンが使われる

これを解消します
