### PR TITLE
営業時間外待機中（`waiting_business_hours`）のタスクに対して、ラベル削除やレビュー投稿によるタスク完了処理が正しく動作するよう修正

### DIFF
--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -202,7 +202,7 @@ func handleUnlabeledEvent(c *gin.Context, db *gorm.DB, e *github.PullRequestEven
 	// 該当するレビュータスクを検索
 	var tasks []models.ReviewTask
 	db.Where("repo = ? AND pr_number = ? AND label_name = ? AND status IN (?)", 
-		repoFullName, pr.GetNumber(), labelName, []string{"pending", "in_review", "snoozed"}).Find(&tasks)
+		repoFullName, pr.GetNumber(), labelName, []string{"pending", "in_review", "snoozed", "waiting_business_hours"}).Find(&tasks)
 
 	if len(tasks) == 0 {
 		log.Printf("no active tasks found for unlabeled event: repo=%s, pr=%d, label=%s", repoFullName, pr.GetNumber(), labelName)
@@ -249,7 +249,7 @@ func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 	// 該当するタスクを検索
 	var tasks []models.ReviewTask
 	result := db.Where("repo = ? AND pr_number = ? AND status IN ?",
-		repoFullName, pr.GetNumber(), []string{"in_review", "pending"}).Find(&tasks)
+		repoFullName, pr.GetNumber(), []string{"in_review", "pending", "waiting_business_hours"}).Find(&tasks)
 
 	if result.Error != nil {
 		log.Printf("review submitted task search error: %v", result.Error)

--- a/handlers/webhook_test.go
+++ b/handlers/webhook_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"slack-review-notify/models"
+	"slack-review-notify/services"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-github/v71/github"
 	"github.com/h2non/gock"
-	"slack-review-notify/models"
-	"slack-review-notify/services"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -154,6 +155,91 @@ func TestUnlabeledEventWithoutExistingTask(t *testing.T) {
 	assert.Equal(t, int64(0), taskCount)
 }
 
+func TestUnlabeledEventWithWaitingBusinessHoursTask(t *testing.T) {
+	// セットアップ
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	// チャンネル設定を作成
+	config := models.ChannelConfig{
+		SlackChannelID:   "C1234567890",
+		LabelName:        "needs-review",
+		DefaultMentionID: "@here",
+		RepositoryList:   "",
+		IsActive:         true,
+	}
+	db.Create(&config)
+
+	// 営業時間外待機中のレビュータスクを作成
+	task := models.ReviewTask{
+		ID:           "waiting-task-id",
+		PRURL:        "https://github.com/test/repo/pull/789",
+		Repo:         "test/repo",
+		PRNumber:     789,
+		Title:        "Waiting Business Hours PR",
+		SlackTS:      "1234567890.789012",
+		SlackChannel: "C1234567890",
+		Status:       "waiting_business_hours", // 営業時間外待機中
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	// unlabeledイベントのペイロードを作成
+	prNumber := 789
+	repoName := "repo"
+	ownerLogin := "test"
+	prTitle := "Waiting Business Hours PR"
+	prHTMLURL := "https://github.com/test/repo/pull/789"
+	labelName := "needs-review"
+	action := "unlabeled"
+	
+	payload := github.PullRequestEvent{
+		Action: &action,
+		Number: &prNumber,
+		Label: &github.Label{
+			Name: &labelName,
+		},
+		PullRequest: &github.PullRequest{
+			Number:  &prNumber,
+			Title:   &prTitle,
+			HTMLURL: &prHTMLURL,
+		},
+		Repo: &github.Repository{
+			Name: &repoName,
+			Owner: &github.User{
+				Login: &ownerLogin,
+			},
+		},
+	}
+
+	// HTTPリクエストを作成
+	jsonData, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+
+	// レスポンスレコーダー作成
+	w := httptest.NewRecorder()
+
+	// Ginルーターを作成してリクエスト実行
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	// HTTPステータスが200であることを確認
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// タスクが完了状態に更新されたことを確認
+	var updatedTask models.ReviewTask
+	result := db.Where("id = ?", "waiting-task-id").First(&updatedTask)
+	assert.NoError(t, result.Error)
+	assert.Equal(t, "completed", updatedTask.Status)
+	assert.True(t, updatedTask.UpdatedAt.After(task.UpdatedAt))
+}
+
 func TestHandleReviewSubmittedEvent(t *testing.T) {
 	// テスト用DB
 	db := setupTestDB(t)
@@ -236,3 +322,101 @@ func TestHandleReviewSubmittedEvent(t *testing.T) {
 	assert.True(t, gock.IsDone(), "すべてのモックが使用されていません")
 }
 
+func TestHandleReviewSubmittedEventWithWaitingBusinessHoursTask(t *testing.T) {
+	// テスト用DB
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+	
+	// テスト前の環境変数を保存し、テスト後に復元
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer os.Setenv("SLACK_BOT_TOKEN", originalToken)
+
+	// テスト用の環境変数を設定
+	os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	// モックの設定
+	defer gock.Off() // テスト終了時にモックをクリア
+
+	// Slack API成功レスポンスのモック
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		MatchHeader("Authorization", "Bearer test-token").
+		Reply(200).
+		JSON(map[string]interface{}{
+			"ok": true,
+			"ts": "1234567890.123456",
+			"channel": "C1234567890",
+		})
+
+	// 営業時間外待機中のレビュータスクを作成
+	task := models.ReviewTask{
+		ID:           "waiting-review-task-id",
+		PRURL:        "https://github.com/test/repo/pull/999",
+		Repo:         "test/repo",
+		PRNumber:     999,
+		Title:        "Waiting Business Hours Review PR",
+		SlackTS:      "1234567890.999888",
+		SlackChannel: "C1234567890",
+		Status:       "waiting_business_hours", // 営業時間外待機中
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	// レビュー投稿イベントのペイロードを作成
+	prNumber := 999
+	repoName := "repo"
+	ownerLogin := "test"
+	reviewerLogin := "reviewer"
+	reviewState := "approved"
+	reviewBody := "LGTM!"
+	
+	payload := github.PullRequestReviewEvent{
+		Action: github.String("submitted"),
+		PullRequest: &github.PullRequest{
+			Number: &prNumber,
+		},
+		Repo: &github.Repository{
+			Name: &repoName,
+			Owner: &github.User{
+				Login: &ownerLogin,
+			},
+		},
+		Review: &github.PullRequestReview{
+			User: &github.User{
+				Login: &reviewerLogin,
+			},
+			State: &reviewState,
+			Body:  &reviewBody,
+		},
+	}
+
+	// HTTPリクエストを作成
+	jsonData, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/webhook", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	// レスポンスレコーダー作成
+	w := httptest.NewRecorder()
+
+	// Ginルーターを作成してリクエスト実行
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	// HTTPステータスが200であることを確認
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// タスクが完了状態に更新されたことを確認
+	var updatedTask models.ReviewTask
+	result := db.Where("id = ?", "waiting-review-task-id").First(&updatedTask)
+	assert.NoError(t, result.Error)
+	assert.Equal(t, "completed", updatedTask.Status)
+	assert.True(t, updatedTask.UpdatedAt.After(task.UpdatedAt))
+	
+	// モックが使用されたことを確認（Slack API呼び出しが行われた）
+	assert.True(t, gock.IsDone(), "すべてのモックが使用されていません")
+}

--- a/handlers/webhook_test.go
+++ b/handlers/webhook_test.go
@@ -374,7 +374,7 @@ func TestHandleReviewSubmittedEventWithWaitingBusinessHoursTask(t *testing.T) {
 	reviewBody := "LGTM!"
 	
 	payload := github.PullRequestReviewEvent{
-		Action: github.String("submitted"),
+		Action: github.Ptr("submitted"),
 		PullRequest: &github.PullRequest{
 			Number: &prNumber,
 		},

--- a/services/slack.go
+++ b/services/slack.go
@@ -129,7 +129,18 @@ func SendSlackMessageOffHours(prURL, title, channel string) (string, string, err
 			Type: "section",
 			Text: &TextObject{
 				Type: "mrkdwn",
-				Text: fmt.Sprintf("📝 *新しいレビュー対象のPRが登録されました*\n\n*PRタイトル*: %s\n*URL*: <%s>\n\n⏰ レビューのメンションは翌営業日の朝（10時）にお送りします", title, prURL),
+				Text: fmt.Sprintf("📝 *レビュー対象のPRが登録されました*\n\n*PRタイトル*: %s\n*URL*: <%s>\n\n (営業時間を過ぎているので、レビューのメンションは翌営業日の朝（10時）にお送りします)", title, prURL),
+			},
+		},
+		{
+			Type: "actions",
+			Elements: []Button{
+				{
+					Type:     "button",
+					Text:     TextObject{Type: "plain_text", Text: "レビュー完了"},
+					ActionID: "review_done",
+					Style:    "primary",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## 概要
営業時間外待機中（`waiting_business_hours`）のタスクに対して、ラベル削除やレビュー投稿によるタスク完了処理が正しく動作するよう修正。営業時間外メッセージにもレビュー完了ボタンを追加し、より柔軟な完了方法を提供。

### 変更内容
- **unlabeledイベント処理の修正**
  - `handleUnlabeledEvent`で`waiting_business_hours`状態のタスクも検索対象に追加
  - 営業時間外待機中のPRからラベルを削除した際に、正しくタスク完了処理が実行される
- **レビュー投稿イベント処理の修正**
  - `handleReviewSubmittedEvent`で`waiting_business_hours`状態のタスクも検索対象に追加
  - 営業時間外待機中のPRでレビューコメントを投稿した際に、スレッドに完了通知が投稿される
- **営業時間外メッセージUI改善**
  - `SendSlackMessageOffHours`にレビュー完了ボタンを追加
  - 営業時間外でもレビューが可能な場合に、その場で完了処理を行える
  - メッセージ文言の微調整（「新しい」を削除、説明文の調整）
- **包括的なテストスイート追加**
  - `TestUnlabeledEventWithWaitingBusinessHoursTask`: 営業時間外待機中タスクのラベル削除テスト
  - `TestHandleReviewSubmittedEventWithWaitingBusinessHoursTask`: 営業時間外待機中タスクのレビュー投稿テスト

### 期待すること
- **完了処理の一貫性**: 営業時間外待機中のタスクでも、ラベル削除・レビュー投稿・ボタン押下のいずれの方法でも確実にタスク完了処理が実行される
- **翌営業日通知の回避**: 営業時間外にレビューが完了した場合、翌営業日朝の不要なメンション通知が送られることがなくなる
- **ユーザー体験の向上**: 営業時間外でも見れる人がレビューした場合に、その場で完了処理を行えるため、チーム全体の効率が向上
- **データ整合性の保証**: 営業時間外待機中のタスクが正しいステータス遷移（`waiting_business_hours` → `completed`）を行う
