### PR TITLE
ボタン設定が空文字だった場合のバグ対応

### DIFF
--- a/services/slack.go
+++ b/services/slack.go
@@ -125,7 +125,7 @@ func SelectRandomReviewer(db *gorm.DB, channelID string, labelName string) strin
 // SendSlackMessageOffHours は営業時間外用のメンション抜きメッセージを送信する
 func SendSlackMessageOffHours(prURL, title, channel string) (string, string, error) {
 	message := fmt.Sprintf("📝 *レビュー対象のPRが登録されました*\n\n*PRタイトル*: %s\n*URL*: <%s>\n\n (レビューのメンションは翌営業日の朝（10時）にお送りします)", title, prURL)
-	doneButton := CreateButton("レビュー完了", "review_done", "", "primary")
+	doneButton := CreateButton("レビュー完了", "review_done", "done", "primary")
 	blocks := CreateMessageWithActionBlocks(message, doneButton)
 
 	body := map[string]interface{}{
@@ -239,7 +239,7 @@ func SendSlackMessage(prURL, title, channel, mentionID string) (string, string, 
 	}
 
 	message := fmt.Sprintf("%s *レビュー対象のPRがあります！*\n\n*PRタイトル*: %s\n*URL*: <%s>", mentionText, title, prURL)
-	doneButton := CreateButton("レビュー完了", "review_done", "", "primary")
+	doneButton := CreateButton("レビュー完了", "review_done", "done", "primary")
 	blocks := CreateMessageWithActionBlocks(message, doneButton)
 
 	body := map[string]interface{}{

--- a/services/slack_blocks.go
+++ b/services/slack_blocks.go
@@ -72,6 +72,10 @@ func (b *SlackBlockBuilder) Build() []map[string]interface{} {
 
 // CreateButton ボタン要素を作成
 func CreateButton(text, actionID, value, style string) map[string]interface{} {
+	if value == "" {
+		value = "default"
+	}
+	
 	button := map[string]interface{}{
 		"type": "button",
 		"text": map[string]interface{}{
@@ -91,6 +95,13 @@ func CreateButton(text, actionID, value, style string) map[string]interface{} {
 
 // CreatePauseReminderSelect リマインダー停止セレクトを作成
 func CreatePauseReminderSelect(taskID, actionID, placeholder string, options []PauseOption) map[string]interface{} {
+	if taskID == "" {
+		taskID = "unknown"
+	}
+	if placeholder == "" {
+		placeholder = "選択してください"
+	}
+	
 	selectOptions := make([]map[string]interface{}, len(options))
 	for i, option := range options {
 		selectOptions[i] = map[string]interface{}{
@@ -130,6 +141,9 @@ func CreateStopOnlyPauseReminderSelect(taskID, actionID, placeholder string) map
 
 // CreateMessageBlocks メッセージのみのブロックを作成
 func CreateMessageBlocks(message string) []map[string]interface{} {
+	if message == "" {
+		message = " "
+	}
 	return NewSlackBlockBuilder().
 		AddSection(message).
 		Build()
@@ -137,6 +151,9 @@ func CreateMessageBlocks(message string) []map[string]interface{} {
 
 // CreateMessageWithActionBlocks メッセージと1つのアクションのブロックを作成
 func CreateMessageWithActionBlocks(message string, action map[string]interface{}) []map[string]interface{} {
+	if message == "" {
+		message = " "
+	}
 	return NewSlackBlockBuilder().
 		AddSection(message).
 		AddActions(action).
@@ -145,6 +162,9 @@ func CreateMessageWithActionBlocks(message string, action map[string]interface{}
 
 // CreateMessageWithActionsBlocks メッセージと複数のアクションのブロックを作成
 func CreateMessageWithActionsBlocks(message string, actions ...map[string]interface{}) []map[string]interface{} {
+	if message == "" {
+		message = " "
+	}
 	return NewSlackBlockBuilder().
 		AddSection(message).
 		AddActions(actions...).

--- a/services/slack_blocks_test.go
+++ b/services/slack_blocks_test.go
@@ -170,6 +170,24 @@ func TestCreateButton_NoStyle(t *testing.T) {
 	}
 }
 
+func TestCreateButton_EmptyValue(t *testing.T) {
+	button := CreateButton("Click Me", "click_action", "", "")
+
+	expected := map[string]interface{}{
+		"type": "button",
+		"text": map[string]interface{}{
+			"type": "plain_text",
+			"text": "Click Me",
+		},
+		"action_id": "click_action",
+		"value":     "default",
+	}
+
+	if !reflect.DeepEqual(button, expected) {
+		t.Errorf("expected %+v, got %+v", expected, button)
+	}
+}
+
 func TestCreatePauseReminderSelect(t *testing.T) {
 	options := []PauseOption{
 		{Text: "1時間停止", Value: "1h"},
@@ -322,5 +340,43 @@ func TestCreateMessageWithActionsBlocks(t *testing.T) {
 
 	if !reflect.DeepEqual(blocks, expected) {
 		t.Errorf("expected %+v, got %+v", expected, blocks)
+	}
+}
+
+func TestCreateMessageBlocks_EmptyMessage(t *testing.T) {
+	blocks := CreateMessageBlocks("")
+
+	expected := []map[string]interface{}{
+		{
+			"type": "section",
+			"text": map[string]interface{}{
+				"type": "mrkdwn",
+				"text": " ",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(blocks, expected) {
+		t.Errorf("expected %+v, got %+v", expected, blocks)
+	}
+}
+
+func TestCreatePauseReminderSelect_EmptyValues(t *testing.T) {
+	options := []PauseOption{
+		{Text: "停止", Value: "stop"},
+	}
+	
+	selectElement := CreatePauseReminderSelect("", "", "", options)
+
+	// taskIDとplaceholderにデフォルト値が設定されることを確認
+	placeholderObj := selectElement["placeholder"].(map[string]interface{})
+	if placeholderObj["text"] != "選択してください" {
+		t.Errorf("expected default placeholder, got %v", placeholderObj["text"])
+	}
+
+	optionsArray := selectElement["options"].([]map[string]interface{})
+	expectedValue := "unknown:stop"
+	if optionsArray[0]["value"] != expectedValue {
+		t.Errorf("expected %s, got %v", expectedValue, optionsArray[0]["value"])
 	}
 }


### PR DESCRIPTION
[slack-builder-component](https://github.com/haruotsu/slack-review-notify/tree/slack-builder-component) に組み込む