### PR TITLE
Slack Block Builder共通化リファクタリング + slack blockのパラメータが空だった場合の処理

### DIFF
--- a/services/slack.go
+++ b/services/slack.go
@@ -125,7 +125,7 @@ func SelectRandomReviewer(db *gorm.DB, channelID string, labelName string) strin
 // SendSlackMessageOffHours は営業時間外用のメンション抜きメッセージを送信する
 func SendSlackMessageOffHours(prURL, title, channel string) (string, string, error) {
 	message := fmt.Sprintf("📝 *レビュー対象のPRが登録されました*\n\n*PRタイトル*: %s\n*URL*: <%s>\n\n (レビューのメンションは翌営業日の朝（10時）にお送りします)", title, prURL)
-	doneButton := CreateButton("レビュー完了", "review_done", "", "primary")
+	doneButton := CreateButton("レビュー完了", "review_done", "done", "primary")
 	blocks := CreateMessageWithActionBlocks(message, doneButton)
 
 	body := map[string]interface{}{
@@ -239,7 +239,7 @@ func SendSlackMessage(prURL, title, channel, mentionID string) (string, string, 
 	}
 
 	message := fmt.Sprintf("%s *レビュー対象のPRがあります！*\n\n*PRタイトル*: %s\n*URL*: <%s>", mentionText, title, prURL)
-	doneButton := CreateButton("レビュー完了", "review_done", "", "primary")
+	doneButton := CreateButton("レビュー完了", "review_done", "done", "primary")
 	blocks := CreateMessageWithActionBlocks(message, doneButton)
 
 	body := map[string]interface{}{

--- a/services/slack_blocks.go
+++ b/services/slack_blocks.go
@@ -72,6 +72,10 @@ func (b *SlackBlockBuilder) Build() []map[string]interface{} {
 
 // CreateButton ボタン要素を作成
 func CreateButton(text, actionID, value, style string) map[string]interface{} {
+	if value == "" {
+		value = "default"
+	}
+	
 	button := map[string]interface{}{
 		"type": "button",
 		"text": map[string]interface{}{
@@ -91,6 +95,13 @@ func CreateButton(text, actionID, value, style string) map[string]interface{} {
 
 // CreatePauseReminderSelect リマインダー停止セレクトを作成
 func CreatePauseReminderSelect(taskID, actionID, placeholder string, options []PauseOption) map[string]interface{} {
+	if taskID == "" {
+		taskID = "unknown"
+	}
+	if placeholder == "" {
+		placeholder = "選択してください"
+	}
+	
 	selectOptions := make([]map[string]interface{}, len(options))
 	for i, option := range options {
 		selectOptions[i] = map[string]interface{}{
@@ -130,6 +141,9 @@ func CreateStopOnlyPauseReminderSelect(taskID, actionID, placeholder string) map
 
 // CreateMessageBlocks メッセージのみのブロックを作成
 func CreateMessageBlocks(message string) []map[string]interface{} {
+	if message == "" {
+		message = " "
+	}
 	return NewSlackBlockBuilder().
 		AddSection(message).
 		Build()
@@ -137,6 +151,9 @@ func CreateMessageBlocks(message string) []map[string]interface{} {
 
 // CreateMessageWithActionBlocks メッセージと1つのアクションのブロックを作成
 func CreateMessageWithActionBlocks(message string, action map[string]interface{}) []map[string]interface{} {
+	if message == "" {
+		message = " "
+	}
 	return NewSlackBlockBuilder().
 		AddSection(message).
 		AddActions(action).
@@ -145,6 +162,9 @@ func CreateMessageWithActionBlocks(message string, action map[string]interface{}
 
 // CreateMessageWithActionsBlocks メッセージと複数のアクションのブロックを作成
 func CreateMessageWithActionsBlocks(message string, actions ...map[string]interface{}) []map[string]interface{} {
+	if message == "" {
+		message = " "
+	}
 	return NewSlackBlockBuilder().
 		AddSection(message).
 		AddActions(actions...).

--- a/services/slack_blocks_test.go
+++ b/services/slack_blocks_test.go
@@ -170,6 +170,24 @@ func TestCreateButton_NoStyle(t *testing.T) {
 	}
 }
 
+func TestCreateButton_EmptyValue(t *testing.T) {
+	button := CreateButton("Click Me", "click_action", "", "")
+
+	expected := map[string]interface{}{
+		"type": "button",
+		"text": map[string]interface{}{
+			"type": "plain_text",
+			"text": "Click Me",
+		},
+		"action_id": "click_action",
+		"value":     "default",
+	}
+
+	if !reflect.DeepEqual(button, expected) {
+		t.Errorf("expected %+v, got %+v", expected, button)
+	}
+}
+
 func TestCreatePauseReminderSelect(t *testing.T) {
 	options := []PauseOption{
 		{Text: "1時間停止", Value: "1h"},
@@ -322,5 +340,43 @@ func TestCreateMessageWithActionsBlocks(t *testing.T) {
 
 	if !reflect.DeepEqual(blocks, expected) {
 		t.Errorf("expected %+v, got %+v", expected, blocks)
+	}
+}
+
+func TestCreateMessageBlocks_EmptyMessage(t *testing.T) {
+	blocks := CreateMessageBlocks("")
+
+	expected := []map[string]interface{}{
+		{
+			"type": "section",
+			"text": map[string]interface{}{
+				"type": "mrkdwn",
+				"text": " ",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(blocks, expected) {
+		t.Errorf("expected %+v, got %+v", expected, blocks)
+	}
+}
+
+func TestCreatePauseReminderSelect_EmptyValues(t *testing.T) {
+	options := []PauseOption{
+		{Text: "停止", Value: "stop"},
+	}
+	
+	selectElement := CreatePauseReminderSelect("", "", "", options)
+
+	// taskIDとplaceholderにデフォルト値が設定されることを確認
+	placeholderObj := selectElement["placeholder"].(map[string]interface{})
+	if placeholderObj["text"] != "選択してください" {
+		t.Errorf("expected default placeholder, got %v", placeholderObj["text"])
+	}
+
+	optionsArray := selectElement["options"].([]map[string]interface{})
+	expectedValue := "unknown:stop"
+	if optionsArray[0]["value"] != expectedValue {
+		t.Errorf("expected %s, got %v", expectedValue, optionsArray[0]["value"])
 	}
 }


### PR DESCRIPTION
## 概要
Slackメッセージの構築処理を共通化し、コードの重複を削減するリファクタリングに加えて、空文字列パラメータによるSlack APIエラーを防ぐ防御的プログラミングを実装しました。これにより、コードの保守性・可読性向上と同時に、運用時のエラー耐性を大幅に強化しました。

### 変更内容
- **新規ファイル作成**: `services/slack_blocks.go` - Block Builder実装とヘルパー関数群（172行）
- **新規ファイル作成**: `services/slack_blocks_test.go` - 包括的テストスイート（382行）  
- **既存ファイル変更**: `services/slack.go` - 全メッセージ構築処理のBlock Builder化（264行削減）

#### 実装した防御的プログラミング機能
1. **空文字列自動補完**:
   - `CreateButton`: 空`value` → `"default"`
   - `CreatePauseReminderSelect`: 空`taskID` → `"unknown"`、空`placeholder` → `"選択してください"`
   - `CreateMessage*Blocks`: 空`message` → `" "`（スペース）

2. **Slack APIエラー対策**:
   - `invalid_blocks`エラーの根本原因を特定・修正
   - ボタンの`value`属性に適切なデフォルト値を設定
   - 空文字列パラメータによるAPI失敗を防止

3. **Block Builderパターン**:
   - `SlackBlockBuilderクラス` - メソッドチェーンによる直感的なブロック構築
   - 高レベルヘルパー関数 - 1行でブロック構築完了
   - リマインダー停止オプション定数化 - 全オプションの統一管理

#### リファクタリング対象関数（8関数）
- `SendSlackMessage()` - 通常のレビュー依頼メッセージ  
- `SendSlackMessageOffHours()` - 営業時間外メッセージ
- `SendReviewerReminderMessage()` - レビュワーリマインド
- `PostReviewerAssignedMessageWithChangeButton()` - レビュワー割り当て通知
- `SendOutOfHoursReminderMessage()` - 営業時間外リマインド
- `UpdateSlackMessageForCompletedTask()` - レビュー完了通知
- `PostBusinessHoursNotificationToThread()` - 営業時間復帰通知
- `PostToThreadWithButtons()` - スレッド投稿

### 期待すること
1. **運用安定性の向上**: 空文字列パラメータによるSlack APIエラーを未然に防止
2. **開発効率の向上**: 新しいSlackメッセージ機能の実装時間を大幅短縮
3. **保守性の向上**: 重複コードの削減により、修正時の影響範囲を最小化
4. **バグ発生率の低減**: 統一されたパターンとデフォルト値設定でヒューマンエラーを防止
5. **可読性の向上**: ブロック構築ロジックが明確になり、コードレビューが容易
6. **テスト容易性**: 各ヘルパー関数が独立してテスト可能
