### PR TITLE
自動レビュワー割り当てメッセージの改善とテストの安定化

### DIFF
--- a/services/slack.go
+++ b/services/slack.go
@@ -563,7 +563,7 @@ func IsChannelArchived(channelID string) (bool, error) {
 
 // 自動割り当てされたレビュワーを表示し、変更ボタンを表示する関数
 func PostReviewerAssignedMessageWithChangeButton(task models.ReviewTask) error {
-	message := fmt.Sprintf("<@%s> レビューしてくれたら嬉しいです...👀", task.Reviewer)
+	message := fmt.Sprintf("自動でレビュワーが割り当てられました: <@%s> レビューをお願いします！", task.Reviewer)
 
 	changeButton := CreateChangeReviewerButton(task.ID)
 	pauseSelect := CreateAllOptionsPauseReminderSelect(task.ID, "pause_reminder_initial", "リマインダーを停止")


### PR DESCRIPTION
## 概要
自動レビュワー割り当て時のSlackメッセージをよりプロフェッショナルな内容に変更し、CIでのテストの安定性を向上させる修正を実施。

### 変更内容
- 自動レビュワー割り当てメッセージを「<@user> レビューしてくれたら嬉しいです...👀」から「自動でレビュワーが割り当てられました: <@user> レビューをお願いします！」に変更
- `TestGetNextBusinessDayMorning`テストを現在時刻に依存しない固定時刻テストに変更し、CI環境での実行時刻による不安定さを解消
- テストケースでJSTタイムゾーンを明示的に使用するように修正

### 期待すること
- よりプロフェッショナルで明確なレビュー依頼メッセージによるユーザー体験の向上
- CI環境での実行時刻に関係なく安定してテストが通ることによる開発効率の向上
- タイムゾーン処理が明確になることによるバグの減少
