### PR TITLE
営業時間外リマインドメッセージに停止ボタンはいらない

### DIFF
--- a/services/slack.go
+++ b/services/slack.go
@@ -686,12 +686,11 @@ func GetNextBusinessDayMorningWithTime(now time.Time) time.Time {
 
 // SendOutOfHoursReminderMessage は営業時間外のリマインドメッセージを送信する
 func SendOutOfHoursReminderMessage(db *gorm.DB, task models.ReviewTask) error {
-	message := fmt.Sprintf("<@%s> レビューしてくれたら嬉しいです...👀\n\n営業時間外のため、次回のリマインドは翌営業日に送信します。", task.Reviewer)
+	message := fmt.Sprintf("<@%s> レビューしてくれたら嬉しいです...👀\n\n*営業時間外のため、次回のリマインドは翌営業日に送信します。*", task.Reviewer)
 
-	pauseSelect := CreateStopOnlyPauseReminderSelect(task.ID, "pause_reminder", "リマインダーを停止")
-	blocks := CreateMessageWithActionBlocks(message, pauseSelect)
+	blocks := CreateMessageBlocks(message)
 
-	// スレッドにボタン付きメッセージを投稿
+	// スレッドにメッセージを投稿
 	body := map[string]interface{}{
 		"channel":   task.SlackChannel,
 		"thread_ts": task.SlackTS,


### PR DESCRIPTION
## 概要
自動レビュワー割り当て時のSlackメッセージをよりプロフェッショナルな内容に変更し、CIでのテストの安定性を向上させ、営業時間外リマインド機能のUIを改善。

### 変更内容
- 自動レビュワー割り当てメッセージを「<@user> レビューしてくれたら嬉しいです...👀」から「自動でレビュワーが割り当てられました: <@user> レビューをお願いします！」に変更
- `TestGetNextBusinessDayMorning`テストを現在時刻に依存しない固定時刻テストに変更し、CI環境での実行時刻による不安定さを解消
- テストケースでJSTタイムゾーンを明示的に使用するように修正
- 営業時間外リマインドメッセージから不要な「リマインダーを停止」ボタンを削除
- 営業時間外の説明文を太字表示に変更して視認性を向上

### 期待すること
- よりプロフェッショナルで明確なレビュー依頼メッセージによるユーザー体験の向上
- CI環境での実行時刻に関係なく安定してテストが通ることによる開発効率の向上
- タイムゾーン処理が明確になることによるバグの減少
- 営業時間外リマインドのUIが簡潔になり、混乱を避けることができる
- 営業時間外の状況がより明確に伝わる
