### PR TITLE
Revert "営業時間外リマインドメッセージに停止ボタンはいらない"

### DIFF
--- a/services/slack.go
+++ b/services/slack.go
@@ -686,11 +686,12 @@ func GetNextBusinessDayMorningWithTime(now time.Time) time.Time {
 
 // SendOutOfHoursReminderMessage は営業時間外のリマインドメッセージを送信する
 func SendOutOfHoursReminderMessage(db *gorm.DB, task models.ReviewTask) error {
-	message := fmt.Sprintf("<@%s> レビューしてくれたら嬉しいです...👀\n\n*営業時間外のため、次回のリマインドは翌営業日に送信します。*", task.Reviewer)
+	message := fmt.Sprintf("<@%s> レビューしてくれたら嬉しいです...👀\n\n営業時間外のため、次回のリマインドは翌営業日に送信します。", task.Reviewer)
 
-	blocks := CreateMessageBlocks(message)
+	pauseSelect := CreateStopOnlyPauseReminderSelect(task.ID, "pause_reminder", "リマインダーを停止")
+	blocks := CreateMessageWithActionBlocks(message, pauseSelect)
 
-	// スレッドにメッセージを投稿
+	// スレッドにボタン付きメッセージを投稿
 	body := map[string]interface{}{
 		"channel":   task.SlackChannel,
 		"thread_ts": task.SlackTS,


### PR DESCRIPTION
Reverts haruotsu/slack-review-notify#37

リマインダ通知を止めたい場合もあるので、完全に停止ボタンだけは出しておいて良さそうなので、戻します