### PR TITLE
固定されていた営業時間を、チャンネルごとに個別設定可能にし、タイムゾーン対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 ## 機能
 - **Slackコマンドによる設定管理**: すべての設定をSlackから変更可能
 - **自動通知**: PRにラベルが付けられると、設定されたSlackチャンネルに通知
-- **営業時間外待機機能**: 営業時間外（平日10:00-18:59以外）にPRにラベルが付けられた場合、営業時間内まで待機してから通知
+- **カスタマイズ可能な営業時間**: チャンネルごとに営業時間を個別設定、深夜営業にも対応
+- **タイムゾーン対応**: グローバルチームでの運用を支援（JST、UTC、その他多数対応）
+- **営業時間外待機機能**: 営業時間外にPRにラベルが付けられた場合、営業時間内まで待機してから通知
 - **ランダムレビュワー選択**: 設定されたレビュワーリストからランダムに選択
 - **定期リマインド**: レビューが完了するまで、設定した頻度でリマインド
 - **営業時間外リマインド制御**: 営業時間外は1回のみリマインド、2回目以降は翌営業日まで待機
@@ -72,6 +74,9 @@ DB_PATH=review_tasks.db  # デフォルト: review_tasks.db（省略可能）
 - `/slack-review-notify [ラベル名] remove-repo owner/repo`: 通知対象リポジトリを削除
 - `/slack-review-notify [ラベル名] set-label 新ラベル名`: ラベル名を変更
 - `/slack-review-notify [ラベル名] set-reviewer-reminder-interval 30`: レビュワー割り当て後のリマインド頻度を設定（分単位）
+- `/slack-review-notify [ラベル名] set-business-hours-start 09:00`: 営業時間の開始時刻を設定（HH:MM形式）
+- `/slack-review-notify [ラベル名] set-business-hours-end 18:00`: 営業時間の終了時刻を設定（HH:MM形式）
+- `/slack-review-notify [ラベル名] set-timezone Asia/Tokyo`: タイムゾーンを設定（例: `Asia/Tokyo`, `UTC`, `America/New_York`）
 - `/slack-review-notify [ラベル名] activate`: このラベルの通知を有効化
 - `/slack-review-notify [ラベル名] deactivate`: このラベルの通知を無効化
 
@@ -85,10 +90,16 @@ GitHubでレビューが行われると、自動的に感謝メッセージが�
 - コメント時: `💬 reviewerさんがレビューコメントを残しました 感謝！👏`
 
 #### 📅 営業時間外待機機能
-営業時間外（平日10:00-18:59以外の土日・夜間）にPRにラベルが付けられた場合：
+営業時間外にPRにラベルが付けられた場合：
 - 即座に通知せず、営業時間内まで待機
 - 営業時間になると自動的にレビュワーをアサインして通知
 - チームメンバーに迷惑をかけることなく適切な時間にレビュー依頼が可能
+
+**営業時間の設定**
+- デフォルト: 平日9:00-18:00（JST）
+- チャンネルごとに個別に設定可能
+- 深夜営業（日をまたぐ時間）にも対応（例: 22:00-06:00）
+- タイムゾーン設定により、グローバルチームでの運用にも対応
 
 #### 📱 手動操作
 - 「レビュー完了」ボタン: 手動でレビュー完了として記録（`✅ <@user> さんがレビューを完了しました！感謝！👏`）
@@ -96,6 +107,42 @@ GitHubでレビューが行われると、自動的に感謝メッセージが�
 - 初回リマインダー一時停止: レビュワー割り当て時に事前にリマインダーを一時停止可能
 - リマインダー一時停止: 1時間, 2時間, 4時間, 今日は通知しない (翌営業日の朝まで停止), 完全停止のパターンで変更
 
+### 設定例
+#### 営業時間とタイムゾーンの設定
+```bash
+# 営業時間を9:00-18:00に設定
+/slack-review-notify set-business-hours-start 09:00
+/slack-review-notify set-business-hours-end 18:00
+
+# タイムゾーンを日本に設定
+/slack-review-notify set-timezone Asia/Tokyo
+
+# 深夜営業チーム（22:00-06:00）の場合
+/slack-review-notify night-shift set-business-hours-start 22:00
+/slack-review-notify night-shift set-business-hours-end 06:00
+/slack-review-notify night-shift set-timezone Asia/Tokyo
+
+# アメリカチームの場合
+/slack-review-notify us-team set-business-hours-start 09:00
+/slack-review-notify us-team set-business-hours-end 17:00
+/slack-review-notify us-team set-timezone America/New_York
+
+# 設定確認
+/slack-review-notify show
+```
+
+#### 基本的な通知設定
+```bash
+# needs-reviewラベル用の設定
+/slack-review-notify add-repo owner/repository
+/slack-review-notify set-mention @team-lead
+/slack-review-notify add-reviewer @reviewer1,@reviewer2,@reviewer3
+
+# securityラベル用の設定
+/slack-review-notify security add-repo owner/repository
+/slack-review-notify security set-mention @security-team
+/slack-review-notify security add-reviewer @security-expert1,@security-expert2
+```
 
 ## 開発
 

--- a/handlers/command_db_test.go
+++ b/handlers/command_db_test.go
@@ -1,0 +1,176 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slack-review-notify/models"
+	"slack-review-notify/services"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// setupCommandIntegrationTestDB creates an in-memory database for integration tests
+func setupCommandIntegrationTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("fail to open test db: %v", err)
+	}
+
+	if err := db.AutoMigrate(&models.ChannelConfig{}, &models.ReviewTask{}); err != nil {
+		t.Fatalf("fail to migrate test db: %v", err)
+	}
+
+	return db
+}
+
+func setupHTTPRequest(t *testing.T, text, channelID string) *http.Request {
+	data := url.Values{}
+	data.Set("command", "/slack-review-notify")
+	data.Set("text", text)
+	data.Set("channel_id", channelID)
+	data.Set("user_id", "U12345")
+
+	req, err := http.NewRequest("POST", "/slack/command", strings.NewReader(data.Encode()))
+	if err != nil {
+		t.Fatalf("fail to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req
+}
+
+func TestSetBusinessHoursStartCommand_Integration(t *testing.T) {
+	db := setupCommandIntegrationTestDB(t)
+	
+	services.IsTestMode = true
+	defer func() {
+		services.IsTestMode = false
+	}()
+
+	tests := []struct {
+		name            string
+		text            string
+		channelID       string
+		expectedStart   string
+		expectedStatus  int
+		expectsError    bool
+	}{
+		{
+			name:            "正常な営業開始時間設定",
+			text:            "needs-review set-business-hours-start 09:00",
+			channelID:       "C12345",
+			expectedStart:   "09:00",
+			expectedStatus:  200,
+			expectsError:    false,
+		},
+		{
+			name:            "デフォルトラベルでの営業開始時間設定",
+			text:            "set-business-hours-start 10:00",
+			channelID:       "C67890",
+			expectedStart:   "10:00",
+			expectedStatus:  200,
+			expectsError:    false,
+		},
+		{
+			name:            "無効な時間形式",
+			text:            "needs-review set-business-hours-start 25:00",
+			channelID:       "C12345",
+			expectedStatus:  200,
+			expectsError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			req := setupHTTPRequest(t, tt.text, tt.channelID)
+			w := httptest.NewRecorder()
+
+			router := gin.New()
+			router.POST("/slack/command", HandleSlackCommand(db))
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			if !tt.expectsError {
+				var config models.ChannelConfig
+				labelName := "needs-review"
+
+				err := db.Where("slack_channel_id = ? AND label_name = ?", tt.channelID, labelName).First(&config).Error
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedStart, config.BusinessHoursStart)
+			}
+		})
+	}
+}
+
+func TestSetTimezoneCommand_Integration(t *testing.T) {
+	db := setupCommandIntegrationTestDB(t)
+	
+	services.IsTestMode = true
+	defer func() {
+		services.IsTestMode = false
+	}()
+
+	tests := []struct {
+		name             string
+		text             string
+		channelID        string
+		expectedTimezone string
+		expectedStatus   int
+		expectsError     bool
+	}{
+		{
+			name:             "正常なタイムゾーン設定（JST）",
+			text:             "needs-review set-timezone Asia/Tokyo",
+			channelID:        "C12345",
+			expectedTimezone: "Asia/Tokyo",
+			expectedStatus:   200,
+			expectsError:     false,
+		},
+		{
+			name:             "正常なタイムゾーン設定（UTC）",
+			text:             "needs-review set-timezone UTC",
+			channelID:        "C67890",
+			expectedTimezone: "UTC",
+			expectedStatus:   200,
+			expectsError:     false,
+		},
+		{
+			name:           "無効なタイムゾーン",
+			text:           "needs-review set-timezone Invalid/Timezone",
+			channelID:      "C12345",
+			expectedStatus: 200,
+			expectsError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			req := setupHTTPRequest(t, tt.text, tt.channelID)
+			w := httptest.NewRecorder()
+
+			router := gin.New()
+			router.POST("/slack/command", HandleSlackCommand(db))
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			if !tt.expectsError {
+				var config models.ChannelConfig
+				labelName := "needs-review"
+
+				err := db.Where("slack_channel_id = ? AND label_name = ?", tt.channelID, labelName).First(&config).Error
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedTimezone, config.Timezone)
+			}
+		})
+	}
+}

--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -117,7 +117,7 @@ func handleLabeledEvent(c *gin.Context, db *gorm.DB, e *github.PullRequestEvent)
 		var reviewerID string
 
 		// 営業時間外判定
-		if services.IsOutsideBusinessHours(time.Now()) {
+		if !services.IsWithinBusinessHours(&config, time.Now()) {
 			// 営業時間外の場合：メンション抜きメッセージを送信
 			var err error
 			slackTs, slackChannelID, err = services.SendSlackMessageOffHours(

--- a/models/channel_config.go
+++ b/models/channel_config.go
@@ -16,6 +16,9 @@ type ChannelConfig struct {
 	IsActive                 bool   // 有効/無効フラグ
 	ReminderInterval         int    // リマインド頻度（分単位、デフォルト30分）
 	ReviewerReminderInterval int    // レビュワー割り当て後のリマインド頻度（分単位、デフォルト30分）
+	BusinessHoursStart       string `gorm:"default:'09:00'"` // 営業時間開始（HH:MM形式）
+	BusinessHoursEnd         string `gorm:"default:'18:00'"` // 営業時間終了（HH:MM形式）
+	Timezone                 string `gorm:"default:'Asia/Tokyo'"` // タイムゾーン（デフォルト：JST）
 	CreatedAt                time.Time
 	UpdatedAt                time.Time
 	DeletedAt                gorm.DeletedAt `gorm:"index"`

--- a/models/channel_config_test.go
+++ b/models/channel_config_test.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupChannelConfigTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("fail to open test db: %v", err)
+	}
+
+	// マイグレーションを実行
+	if err := db.AutoMigrate(&ChannelConfig{}); err != nil {
+		t.Fatalf("fail to migrate test db: %v", err)
+	}
+
+	return db
+}
+
+func TestChannelConfig_BusinessHoursFields(t *testing.T) {
+	db := setupChannelConfigTestDB(t)
+
+	// 営業時間フィールドを持つChannelConfigを作成
+	config := ChannelConfig{
+		ID:                    "test-config",
+		SlackChannelID:        "C12345",
+		LabelName:            "needs-review",
+		DefaultMentionID:     "U12345",
+		IsActive:             true,
+		BusinessHoursStart:   "09:00",
+		BusinessHoursEnd:     "18:00",
+		CreatedAt:            time.Now(),
+		UpdatedAt:            time.Now(),
+	}
+
+	// データベースに保存
+	err := db.Create(&config).Error
+	assert.NoError(t, err)
+
+	// データベースから読み取り
+	var savedConfig ChannelConfig
+	err = db.Where("id = ?", "test-config").First(&savedConfig).Error
+	assert.NoError(t, err)
+
+	// 営業時間フィールドが正しく保存・読み取りされていることを確認
+	assert.Equal(t, "09:00", savedConfig.BusinessHoursStart)
+	assert.Equal(t, "18:00", savedConfig.BusinessHoursEnd)
+}
+
+func TestChannelConfig_DefaultBusinessHours(t *testing.T) {
+	db := setupChannelConfigTestDB(t)
+
+	// 営業時間を指定しないChannelConfigを作成
+	config := ChannelConfig{
+		ID:               "test-config-default",
+		SlackChannelID:   "C12345",
+		LabelName:        "needs-review",
+		DefaultMentionID: "U12345",
+		IsActive:         true,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	// データベースに保存
+	err := db.Create(&config).Error
+	assert.NoError(t, err)
+
+	// データベースから読み取り
+	var savedConfig ChannelConfig
+	err = db.Where("id = ?", "test-config-default").First(&savedConfig).Error
+	assert.NoError(t, err)
+
+	// デフォルト値が設定されていることを確認
+	assert.Equal(t, "09:00", savedConfig.BusinessHoursStart)
+	assert.Equal(t, "18:00", savedConfig.BusinessHoursEnd)
+}

--- a/services/business_hours_check.go
+++ b/services/business_hours_check.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"errors"
+	"slack-review-notify/models"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// IsWithinBusinessHours は指定された時刻が営業時間内かどうかを判定する
+func IsWithinBusinessHours(config *models.ChannelConfig, currentTime time.Time) bool {
+	// 営業時間設定がない場合は常にtrue（通知する）
+	if config == nil || config.BusinessHoursStart == "" || config.BusinessHoursEnd == "" {
+		return true
+	}
+
+	timezone := config.Timezone
+	if timezone == "" {
+		timezone = "Asia/Tokyo"
+	}
+
+	// タイムゾーンに変換
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc, _ = time.LoadLocation("Asia/Tokyo")
+	}
+
+	localTime := currentTime.In(loc)
+
+	currentHour := localTime.Hour()
+	currentMin := localTime.Minute()
+	currentMinutes := currentHour*60 + currentMin
+
+	// 営業開始・終了時刻を解析
+	startHour, startMin, err := parseBusinessHoursTime(config.BusinessHoursStart)
+	if err != nil {
+		return true
+	}
+
+	endHour, endMin, err := parseBusinessHoursTime(config.BusinessHoursEnd)
+	if err != nil {
+		return true
+	}
+
+	startMinutes := startHour*60 + startMin
+	endMinutes := endHour*60 + endMin
+
+	if startMinutes < endMinutes {
+		return currentMinutes >= startMinutes && currentMinutes < endMinutes
+	}
+	return currentMinutes >= startMinutes || currentMinutes < endMinutes
+}
+
+// parseBusinessHoursTime は時刻文字列（HH:MM）を時間と分に解析する
+func parseBusinessHoursTime(timeStr string) (int, int, error) {
+	if timeStr == "" {
+		return 0, 0, errors.New("empty time string")
+	}
+
+	parts := strings.Split(timeStr, ":")
+	if len(parts) != 2 {
+		return 0, 0, errors.New("invalid time format")
+	}
+
+	hour, err := strconv.Atoi(parts[0])
+	if err != nil || hour < 0 || hour > 23 {
+		return 0, 0, errors.New("invalid hour")
+	}
+
+	minute, err := strconv.Atoi(parts[1])
+	if err != nil || minute < 0 || minute > 59 {
+		return 0, 0, errors.New("invalid minute")
+	}
+
+	return hour, minute, nil
+}

--- a/services/business_hours_check_test.go
+++ b/services/business_hours_check_test.go
@@ -1,0 +1,222 @@
+package services
+
+import (
+	"slack-review-notify/models"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsWithinBusinessHours(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       *models.ChannelConfig
+		currentTime  time.Time
+		expected     bool
+	}{
+		{
+			name: "営業時間内（通常時間）",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 12, 30, 0, 0, time.UTC), // 12:30
+			expected:    true,
+		},
+		{
+			name: "営業時間外（早朝）",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 8, 30, 0, 0, time.UTC), // 8:30
+			expected:    false,
+		},
+		{
+			name: "営業時間外（夜間）",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 19, 30, 0, 0, time.UTC), // 19:30
+			expected:    false,
+		},
+		{
+			name: "営業時間開始時刻ちょうど",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 9, 0, 0, 0, time.UTC), // 9:00
+			expected:    true,
+		},
+		{
+			name: "営業時間終了時刻ちょうど",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 18, 0, 0, 0, time.UTC), // 18:00
+			expected:    false, // 終了時刻は含まない
+		},
+		{
+			name: "営業時間設定がない場合（デフォルト値）",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "",
+				BusinessHoursEnd:   "",
+			},
+			currentTime: time.Date(2023, 12, 15, 12, 30, 0, 0, time.UTC), // 12:30
+			expected:    true, // 営業時間設定がない場合は常に通知
+		},
+		{
+			name: "深夜営業（22:00-06:00）の営業時間内",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "22:00",
+				BusinessHoursEnd:   "06:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 23, 30, 0, 0, time.UTC), // 23:30
+			expected:    true,
+		},
+		{
+			name: "深夜営業（22:00-06:00）の営業時間内（早朝）",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "22:00",
+				BusinessHoursEnd:   "06:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 3, 30, 0, 0, time.UTC), // 3:30
+			expected:    true,
+		},
+		{
+			name: "深夜営業（22:00-06:00）の営業時間外",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "22:00",
+				BusinessHoursEnd:   "06:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 12, 30, 0, 0, time.UTC), // 12:30
+			expected:    false,
+		},
+		{
+			name: "UTC設定での営業時間内",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 12, 30, 0, 0, time.UTC), // 12:30 UTC
+			expected:    true,
+		},
+		{
+			name: "UTC設定での営業時間外",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "UTC",
+			},
+			currentTime: time.Date(2023, 12, 15, 19, 30, 0, 0, time.UTC), // 19:30 UTC
+			expected:    false,
+		},
+		{
+			name: "JST設定での営業時間内（UTC時刻で入力）",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "Asia/Tokyo",
+			},
+			currentTime: time.Date(2023, 12, 15, 3, 30, 0, 0, time.UTC), // 3:30 UTC = 12:30 JST
+			expected:    true,
+		},
+		{
+			name: "JST設定での営業時間外（UTC時刻で入力）",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "09:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:           "Asia/Tokyo",
+			},
+			currentTime: time.Date(2023, 12, 15, 10, 30, 0, 0, time.UTC), // 10:30 UTC = 19:30 JST
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsWithinBusinessHours(tt.config, tt.currentTime)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseBusinessHoursTime(t *testing.T) {
+	tests := []struct {
+		name         string
+		timeStr      string
+		expectedHour int
+		expectedMin  int
+		expectError  bool
+	}{
+		{
+			name:         "正常な時間（09:00）",
+			timeStr:      "09:00",
+			expectedHour: 9,
+			expectedMin:  0,
+			expectError:  false,
+		},
+		{
+			name:         "正常な時間（23:59）",
+			timeStr:      "23:59",
+			expectedHour: 23,
+			expectedMin:  59,
+			expectError:  false,
+		},
+		{
+			name:         "無効な形式（時間のみ）",
+			timeStr:      "09",
+			expectedHour: 0,
+			expectedMin:  0,
+			expectError:  true,
+		},
+		{
+			name:         "無効な時間（25:00）",
+			timeStr:      "25:00",
+			expectedHour: 0,
+			expectedMin:  0,
+			expectError:  true,
+		},
+		{
+			name:         "無効な分（09:60）",
+			timeStr:      "09:60",
+			expectedHour: 0,
+			expectedMin:  0,
+			expectError:  true,
+		},
+		{
+			name:         "空文字列",
+			timeStr:      "",
+			expectedHour: 0,
+			expectedMin:  0,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hour, min, err := parseBusinessHoursTime(tt.timeStr)
+			
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedHour, hour)
+				assert.Equal(t, tt.expectedMin, min)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
固定されていた営業時間（平日10:00-18:59）を、チャンネルごとに個別設定可能にし、さらにタイムゾーン対応を追加することで、グローバルチームでの運用を可能にしました。

### 変更内容
- **営業時間設定機能の追加**
  - `set-business-hours-start` コマンドで営業開始時間を設定
  - `set-business-hours-end` コマンドで営業終了時間を設定
  - 深夜営業（日をまたぐ時間帯）にも対応（例: 22:00-06:00）

- **タイムゾーン設定機能の追加**
  - `set-timezone` コマンドでチャンネルごとのタイムゾーン設定
  - デフォルト: Asia/Tokyo（JST）
  - UTC、America/New_York等、世界各地のタイムゾーンに対応

- **データモデルの拡張**
  - ChannelConfigモデルに`BusinessHoursStart`、`BusinessHoursEnd`、`Timezone`フィールドを追加
  - デフォルト値: 9:00-18:00 (JST)

- **営業時間チェック機能の改善**
  - 固定時間チェックから設定可能な時間チェックへ変更
  - タイムゾーンを考慮した時間判定ロジックの実装
  - 設定がない場合は常に営業時間内として扱う（後方互換性）

- **テスト体系の改善**
  - 単体テストと統合テストを分離してパフォーマンス向上
  - 包括的なテストケースを追加（タイムゾーン変換、深夜営業等）

### 期待すること
- **グローバル対応**: 世界各地のチームが自分のタイムゾーンで営業時間を設定可能
- **柔軟な運用**: 深夜営業、シフト制、24時間体制など多様な働き方に対応
- **チーム効率向上**: 適切な時間にレビュー依頼を通知し、メンバーの負担を軽減
- **既存機能への影響なし**: デフォルト値により既存の設定は維持される
