### PR TITLE
リマインダー停止後の翌営業日通知時間を、従来の10時固定から営業時間設定の開始時刻に動的に変更する機能を実装

### DIFF
--- a/services/business_hours_next_day_test.go
+++ b/services/business_hours_next_day_test.go
@@ -1,0 +1,218 @@
+package services
+
+import (
+	"slack-review-notify/models"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// GetNextBusinessDayMorningWithConfig関数のテスト
+func TestGetNextBusinessDayMorningWithConfig(t *testing.T) {
+	// JST タイムゾーンを取得
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+
+	// 営業時間設定
+	config := &models.ChannelConfig{
+		BusinessHoursStart: "09:00",
+		BusinessHoursEnd:   "18:00",
+		Timezone:          "Asia/Tokyo",
+	}
+
+	testCases := []struct {
+		name        string
+		currentTime time.Time
+		config      *models.ChannelConfig
+		expected    time.Time
+	}{
+		{
+			name:        "月曜8時_同日9時",
+			currentTime: time.Date(2024, 1, 15, 8, 0, 0, 0, jst), // 月曜8時（JST）
+			config:      config,
+			expected:    time.Date(2024, 1, 15, 9, 0, 0, 0, jst), // 同日9時
+		},
+		{
+			name:        "月曜12時_翌日9時",
+			currentTime: time.Date(2024, 1, 15, 12, 0, 0, 0, jst), // 月曜12時（JST）
+			config:      config,
+			expected:    time.Date(2024, 1, 16, 9, 0, 0, 0, jst), // 翌日9時
+		},
+		{
+			name:        "金曜20時_翌週月曜9時",
+			currentTime: time.Date(2024, 1, 19, 20, 0, 0, 0, jst), // 金曜20時（JST）
+			config:      config,
+			expected:    time.Date(2024, 1, 22, 9, 0, 0, 0, jst), // 翌週月曜9時
+		},
+		{
+			name:        "土曜14時_月曜9時",
+			currentTime: time.Date(2024, 1, 20, 14, 0, 0, 0, jst), // 土曜14時（JST）
+			config:      config,
+			expected:    time.Date(2024, 1, 22, 9, 0, 0, 0, jst), // 月曜9時
+		},
+		{
+			name:        "日曜14時_月曜9時",
+			currentTime: time.Date(2024, 1, 21, 14, 0, 0, 0, jst), // 日曜14時（JST）
+			config:      config,
+			expected:    time.Date(2024, 1, 22, 9, 0, 0, 0, jst), // 月曜9時
+		},
+		{
+			name:        "設定がnil_デフォルト10時",
+			currentTime: time.Date(2024, 1, 15, 8, 0, 0, 0, jst), // 月曜8時（JST）
+			config:      nil,
+			expected:    time.Date(2024, 1, 15, 10, 0, 0, 0, jst), // 同日10時（デフォルト）
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetNextBusinessDayMorningWithConfig(tc.currentTime, tc.config)
+			assert.Equal(t, tc.expected, result,
+				"currentTime: %s, expected: %s, got: %s",
+				tc.currentTime.Format("2006-01-02 15:04:05"),
+				tc.expected.Format("2006-01-02 15:04:05"),
+				result.Format("2006-01-02 15:04:05"))
+		})
+	}
+}
+
+// 異なる営業時間設定のテスト
+func TestGetNextBusinessDayMorningWithConfig_DifferentBusinessHours(t *testing.T) {
+	// JST タイムゾーンを取得
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		name          string
+		businessStart string
+		currentTime   time.Time
+		expectedHour  int
+		expectedMin   int
+	}{
+		{
+			name:          "営業開始8時半",
+			businessStart: "08:30",
+			currentTime:   time.Date(2024, 1, 15, 8, 0, 0, 0, jst), // 月曜8時
+			expectedHour:  8,
+			expectedMin:   30,
+		},
+		{
+			name:          "営業開始11時",
+			businessStart: "11:00",
+			currentTime:   time.Date(2024, 1, 15, 10, 0, 0, 0, jst), // 月曜10時
+			expectedHour:  11,
+			expectedMin:   0,
+		},
+		{
+			name:          "営業開始7時",
+			businessStart: "07:00",
+			currentTime:   time.Date(2024, 1, 15, 6, 30, 0, 0, jst), // 月曜6時半
+			expectedHour:  7,
+			expectedMin:   0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &models.ChannelConfig{
+				BusinessHoursStart: tc.businessStart,
+				BusinessHoursEnd:   "18:00",
+				Timezone:          "Asia/Tokyo",
+			}
+
+			result := GetNextBusinessDayMorningWithConfig(tc.currentTime, config)
+			
+			assert.Equal(t, tc.expectedHour, result.Hour(), 
+				"Expected hour %d, got %d", tc.expectedHour, result.Hour())
+			assert.Equal(t, tc.expectedMin, result.Minute(), 
+				"Expected minute %d, got %d", tc.expectedMin, result.Minute())
+		})
+	}
+}
+
+// 無効な営業時間設定のテスト
+func TestGetNextBusinessDayMorningWithConfig_InvalidConfig(t *testing.T) {
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+
+	currentTime := time.Date(2024, 1, 15, 8, 0, 0, 0, jst) // 月曜8時
+
+	testCases := []struct {
+		name   string
+		config *models.ChannelConfig
+	}{
+		{
+			name: "無効な時刻形式",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "invalid",
+				BusinessHoursEnd:   "18:00",
+				Timezone:          "Asia/Tokyo",
+			},
+		},
+		{
+			name: "空の営業開始時刻",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "",
+				BusinessHoursEnd:   "18:00",
+				Timezone:          "Asia/Tokyo",
+			},
+		},
+		{
+			name: "無効な時間",
+			config: &models.ChannelConfig{
+				BusinessHoursStart: "25:00",
+				BusinessHoursEnd:   "18:00",
+				Timezone:          "Asia/Tokyo",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetNextBusinessDayMorningWithConfig(currentTime, tc.config)
+			
+			// 無効な設定の場合、デフォルト（10:00）が使用されることを確認
+			assert.Equal(t, 10, result.Hour(), 
+				"Invalid config should fallback to default hour 10, got %d", result.Hour())
+			assert.Equal(t, 0, result.Minute(), 
+				"Invalid config should fallback to default minute 0, got %d", result.Minute())
+		})
+	}
+}
+
+// 異なるタイムゾーンのテスト
+func TestGetNextBusinessDayMorningWithConfig_DifferentTimezones(t *testing.T) {
+	// UTC タイムゾーンでの時刻
+	utc, err := time.LoadLocation("UTC")
+	assert.NoError(t, err)
+	
+	currentTimeUTC := time.Date(2024, 1, 15, 23, 0, 0, 0, utc) // UTC 23:00（JST 8:00）
+
+	// JST設定
+	configJST := &models.ChannelConfig{
+		BusinessHoursStart: "09:00",
+		BusinessHoursEnd:   "18:00",
+		Timezone:          "Asia/Tokyo",
+	}
+
+	result := GetNextBusinessDayMorningWithConfig(currentTimeUTC, configJST)
+
+	// UTC 23:00はJST 8:00に相当（翌日）
+	// 1月15日 UTC 23:00 = 1月16日 JST 8:00
+	// 営業開始時刻9:00より前なので、同日（1月16日）の9:00が返されるべき
+	expectedJST, _ := time.LoadLocation("Asia/Tokyo")
+	expected := time.Date(2024, 1, 16, 9, 0, 0, 0, expectedJST) // JST 9:00
+
+	// デバッグ情報
+	jstTime := currentTimeUTC.In(expectedJST)
+	t.Logf("UTC input: %s", currentTimeUTC.Format("2006-01-02 15:04:05 MST"))
+	t.Logf("JST time: %s", jstTime.Format("2006-01-02 15:04:05 MST"))
+	t.Logf("Expected: %s", expected.Format("2006-01-02 15:04:05 MST"))
+	t.Logf("Got:      %s", result.Format("2006-01-02 15:04:05 MST"))
+
+	assert.Equal(t, expected, result,
+		"Expected JST time %s, got %s", 
+		expected.Format("2006-01-02 15:04:05 MST"), 
+		result.Format("2006-01-02 15:04:05 MST"))
+}

--- a/services/out_of_hours_reminder_test.go
+++ b/services/out_of_hours_reminder_test.go
@@ -120,7 +120,8 @@ func TestGetNextBusinessDayMorningWithTime_OutOfHours(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetNextBusinessDayMorningWithTime(tt.input)
+			// デフォルト設定（10:00開始）を使用
+			result := GetNextBusinessDayMorningWithConfig(tt.input, nil)
 			assert.Equal(t, tt.expected, result,
 				"翌営業日10時の計算が正しくない: got %v, want %v", result, tt.expected)
 		})

--- a/services/slack_next_business_day_test.go
+++ b/services/slack_next_business_day_test.go
@@ -56,8 +56,8 @@ func TestGetNextBusinessDayMorning_Detailed(t *testing.T) {
 			// このテストは現在の実装では失敗します
 			// 実際のテストのため、GetNextBusinessDayMorningに時刻を渡せるようにする必要があります
 			
-			// 現在の実装をテスト（バグがあることを確認）
-			result := GetNextBusinessDayMorning()
+			// 現在の実装をテスト（デフォルト設定を使用）
+			result := GetNextBusinessDayMorningWithConfig(time.Now(), nil)
 			
 			// 現在の実装では常に「翌日」になるため、このテストは失敗するはずです
 			t.Logf("現在時刻: %s", tc.currentTime.Format("2006-01-02 15:04:05"))
@@ -126,8 +126,8 @@ func TestGetNextBusinessDayMorningWithTime(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// GetNextBusinessDayMorningWithTimeをテスト（まだ実装されていない）
-			result := GetNextBusinessDayMorningWithTime(tc.currentTime)
+			// GetNextBusinessDayMorningWithConfigをテスト（デフォルト設定使用）
+			result := GetNextBusinessDayMorningWithConfig(tc.currentTime, nil)
 			
 			assert.Equal(t, tc.expected, result, 
 				"currentTime: %s, expected: %s, got: %s",

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -536,12 +536,12 @@ func TestGetNextBusinessDayMorning(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := GetNextBusinessDayMorningWithTime(tc.baseTime)
+			result := GetNextBusinessDayMorningWithConfig(tc.baseTime, nil)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
 
-	result := GetNextBusinessDayMorning()
+	result := GetNextBusinessDayMorningWithConfig(time.Now(), nil)
 	
 	// 結果は10:00に設定されている
 	assert.Equal(t, 10, result.Hour(), "時刻は10時に設定されていること")

--- a/services/tasks.go
+++ b/services/tasks.go
@@ -132,8 +132,8 @@ func CheckInReviewTasks(db *gorm.DB) {
 							continue
 						}
 					} else {
-						// 翌営業日10時まで一時停止
-						nextBusinessDay := GetNextBusinessDayMorning()
+						// 翌営業日の営業開始時刻まで一時停止
+						nextBusinessDay := GetNextBusinessDayMorningWithConfig(now, &config)
 						task.ReminderPausedUntil = &nextBusinessDay
 						task.OutOfHoursReminded = true
 						task.UpdatedAt = now

--- a/services/tasks_timezone_test.go
+++ b/services/tasks_timezone_test.go
@@ -19,7 +19,7 @@ func TestCheckInReviewTasks_ReminderPausedUntilTimezone(t *testing.T) {
 	baseTimeJST := time.Date(2024, 8, 27, 13, 0, 0, 0, jst)
 	
 	// 翌営業日の朝（JST 10:00）を計算
-	nextBusinessDayJST := GetNextBusinessDayMorningWithTime(baseTimeJST)
+	nextBusinessDayJST := GetNextBusinessDayMorningWithConfig(baseTimeJST, nil)
 	
 	// UTC での同じ時刻
 	baseTimeUTC := baseTimeJST.UTC()
@@ -140,7 +140,7 @@ func TestGetNextBusinessDayMorning_Timezone(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// 翌営業日を計算
-			nextBusinessDay := GetNextBusinessDayMorningWithTime(tt.inputTime)
+			nextBusinessDay := GetNextBusinessDayMorningWithConfig(tt.inputTime, nil)
 
 			// 結果は常に JST で指定された日の 10:00 になるはず
 			assert.Equal(t, 2024, nextBusinessDay.Year(), "Year should be 2024")


### PR DESCRIPTION
## 概要
リマインダー停止後の翌営業日通知時間を、従来の10時固定から営業時間設定の開始時刻に動的に変更する機能を実装。チャンネルごとに設定された営業開始時刻（例：9:00、8:30など）に合わせて、翌営業日の通知時間が自動調整されるようになります。

### 変更内容
- **新関数の実装**: `GetNextBusinessDayMorningWithConfig()` を追加し、ChannelConfigから営業開始時刻を動的に取得
- **レガシー関数の削除**: `GetNextBusinessDayMorning()`, `GetNextBusinessDayMorningWithTime()` を削除してコードを統一
- **呼び出し箇所の更新**:
  - `handlers/slack.go`: 「今日は通知しない」の一時停止機能を営業時間設定対応に修正
  - `services/tasks.go`: 営業時間外リマインド処理を営業時間設定対応に修正
- **包括的テストの追加**: 
  - 異なる営業時間設定（9:00、8:30、11:00など）のテストケース
  - 無効な設定値のフォールバック処理テスト
  - 異なるタイムゾーン対応テスト
  - エラーハンドリングテスト
- **既存テストの更新**: すべてのレガシー関数呼び出しを新関数に統一

### 期待すること
- **営業時間に合わせた柔軟な通知**: チームごとの営業開始時刻（9:00、8:30、11:00など）に合わせて翌営業日通知が自動調整される
- **デフォルト動作の維持**: 営業時間設定がない場合や無効な場合は従来通り10:00に通知（後方互換性）
- **コードの簡素化**: レガシー関数削除により保守性が向上
- **タイムゾーン対応**: 各チャンネルのタイムゾーン設定に応じた正確な時刻計算
