### PR TITLE
複数ラベルAND条件での通知機能追加

### DIFF
--- a/handlers/command.go
+++ b/handlers/command.go
@@ -309,6 +309,13 @@ func showHelp(c *gin.Context) {
 - 例2: /slack-review-notify feature set-mention @開発チーム → featureラベル用の設定
 - 例3: /slack-review-notify security-review set-mention @セキュリティチーム → security-reviewラベル用の設定
 
+*複数ラベルAND条件の設定*
+カンマ区切りで複数のラベルを指定することで、全てのラベルが付いている場合のみ通知します:
+- 例: /slack-review-notify "hoge-project,needs-review" set-mention @team
+  → PRに「hoge-project」と「needs-review」の両方のラベルがある場合のみ通知
+- 例: /slack-review-notify "frontend,urgent,needs-review" add-repo owner/app
+  → 3つのラベル全てが必要
+
 *全コマンド一覧*
 *基本操作:*
 • /slack-review-notify show - このチャンネルの全ラベル設定を表示

--- a/handlers/multiple_label_command_test.go
+++ b/handlers/multiple_label_command_test.go
@@ -1,0 +1,164 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"slack-review-notify/models"
+	"slack-review-notify/services"
+
+	"github.com/gin-gonic/gin"
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultipleLabelCommandHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		command        string
+		text           string
+		expectedStatus int
+		expectedBody   string
+		setupConfig    *models.ChannelConfig
+	}{
+		{
+			name:           "複数ラベルでset-mentionコマンド",
+			command:        "/slack-review-notify",
+			text:           `"hoge-project,needs-review" set-mention @team`,
+			expectedStatus: 200,
+			expectedBody:   "ラベル「hoge-project,needs-review」のメンション先を <@team> に設定しました。",
+		},
+		{
+			name:           "複数ラベルでadd-repoコマンド",
+			command:        "/slack-review-notify",
+			text:           `"frontend,urgent,needs-review" add-repo owner/webapp`,
+			expectedStatus: 200,
+			expectedBody:   "ラベル「frontend,urgent,needs-review」の通知対象リポジトリに `owner/webapp` を追加しました。",
+		},
+		{
+			name:           "複数ラベル設定の表示",
+			command:        "/slack-review-notify",
+			text:           `"project-a,needs-review" show`,
+			expectedStatus: 200,
+			expectedBody:   "*このチャンネルのラベル「project-a,needs-review」のレビュー通知設定*",
+			setupConfig: &models.ChannelConfig{
+				SlackChannelID:   "C1234567890",
+				LabelName:        "project-a,needs-review",
+				DefaultMentionID: "@team",
+				RepositoryList:   "owner/repo",
+				IsActive:         true,
+				CreatedAt:        time.Now(),
+				UpdatedAt:        time.Now(),
+			},
+		},
+		{
+			name:           "スペース付き複数ラベル設定",
+			command:        "/slack-review-notify",
+			text:           `"project a, needs review, urgent" set-mention @team`,
+			expectedStatus: 200,
+			expectedBody:   "ラベル「project a, needs review, urgent」のメンション先を <@team> に設定しました。",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// セットアップ
+			db := setupTestDB(t)
+			gin.SetMode(gin.TestMode)
+			services.IsTestMode = true
+
+			// 既存設定があれば作成
+			if tt.setupConfig != nil {
+				tt.setupConfig.ID = "test-config-id"
+				db.Create(tt.setupConfig)
+			}
+
+			// リクエストボディを作成
+			data := url.Values{}
+			data.Set("command", tt.command)
+			data.Set("text", tt.text)
+			data.Set("channel_id", "C1234567890")
+			data.Set("user_id", "U1234567890")
+
+			// リクエスト作成
+			req, _ := http.NewRequest("POST", "/slack/command", strings.NewReader(data.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			// Slack署名検証をモック（テストモードでスキップ）
+			req.Header.Set("X-Slack-Signature", "test")
+			req.Header.Set("X-Slack-Request-Timestamp", "1234567890")
+
+			w := httptest.NewRecorder()
+
+			// Ginルーターを作成してリクエスト実行
+			router := gin.Default()
+			router.POST("/slack/command", HandleSlackCommand(db))
+			router.ServeHTTP(w, req)
+
+			// HTTPステータス確認
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			// レスポンス内容確認
+			assert.Contains(t, w.Body.String(), tt.expectedBody)
+
+			// データベースに保存されたか確認
+			if strings.Contains(tt.text, "set-mention") || strings.Contains(tt.text, "add-repo") {
+				var config models.ChannelConfig
+				labelName := extractLabelFromText(tt.text)
+				result := db.Where("slack_channel_id = ? AND label_name = ?", "C1234567890", labelName).First(&config)
+				assert.NoError(t, result.Error, "設定がデータベースに保存されていません")
+			}
+
+			// クリーンアップ
+			gock.Off()
+		})
+	}
+}
+
+// テキストからラベル名を抽出するヘルパー関数
+func extractLabelFromText(text string) string {
+	parts := parseCommand(text)
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return "needs-review"
+}
+
+func TestMultipleLabelHelp(t *testing.T) {
+	// セットアップ
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	// helpコマンドのリクエスト
+	data := url.Values{}
+	data.Set("command", "/slack-review-notify")
+	data.Set("text", "help")
+	data.Set("channel_id", "C1234567890")
+	data.Set("user_id", "U1234567890")
+
+	req, _ := http.NewRequest("POST", "/slack/command", strings.NewReader(data.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Slack-Signature", "test")
+	req.Header.Set("X-Slack-Request-Timestamp", "1234567890")
+
+	w := httptest.NewRecorder()
+
+	router := gin.Default()
+	router.POST("/slack/command", HandleSlackCommand(db))
+	router.ServeHTTP(w, req)
+
+	// HTTPステータス確認
+	assert.Equal(t, 200, w.Code)
+
+	// ヘルプメッセージに複数ラベルの説明が含まれているか確認
+	body := w.Body.String()
+	assert.Contains(t, body, "*複数ラベルAND条件の設定*")
+	assert.Contains(t, body, "カンマ区切りで複数のラベルを指定")
+	assert.Contains(t, body, "hoge-project,needs-review")
+	assert.Contains(t, body, "全てのラベルが付いている場合のみ通知")
+}

--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -63,7 +63,6 @@ func handleLabeledEvent(c *gin.Context, db *gorm.DB, e *github.PullRequestEvent)
 	pr := e.PullRequest
 	repo := e.Repo
 	repoFullName := fmt.Sprintf("%s/%s", repo.GetOwner().GetLogin(), repo.GetName())
-	labelName := e.Label.GetName()
 
 	// チャンネル設定を全て取得
 	var configs []models.ChannelConfig
@@ -105,10 +104,10 @@ func handleLabeledEvent(c *gin.Context, db *gorm.DB, e *github.PullRequestEvent)
 			continue
 		}
 
-		// ラベルをチェック
-		if config.LabelName != "" && config.LabelName != labelName {
-			log.Printf("label %s is not watched (channel: %s, config: %s)",
-				labelName, config.SlackChannelID, config.LabelName)
+		// ラベルをチェック（複数ラベル対応）
+		if !services.IsLabelMatched(&config, pr.Labels) {
+			log.Printf("label requirements not met (channel: %s, config: %s)",
+				config.SlackChannelID, config.LabelName)
 			continue
 		}
 

--- a/services/label_matching_test.go
+++ b/services/label_matching_test.go
@@ -1,0 +1,128 @@
+package services
+
+import (
+	"slack-review-notify/models"
+	"testing"
+
+	"github.com/google/go-github/v71/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLabelMatched(t *testing.T) {
+	tests := []struct {
+		name           string
+		configLabels   string
+		prLabels       []*github.Label
+		expectedResult bool
+	}{
+		{
+			name:         "単一ラベル設定で単一ラベルPRがマッチ",
+			configLabels: "needs-review",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("needs-review")},
+			},
+			expectedResult: true,
+		},
+		{
+			name:         "単一ラベル設定で複数ラベルPRがマッチ",
+			configLabels: "needs-review",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("needs-review")},
+				{Name: github.Ptr("bug")},
+				{Name: github.Ptr("priority")},
+			},
+			expectedResult: true,
+		},
+		{
+			name:         "単一ラベル設定でラベルが存在しない",
+			configLabels: "needs-review",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("bug")},
+				{Name: github.Ptr("feature")},
+			},
+			expectedResult: false,
+		},
+		{
+			name:         "複数ラベル設定で全ラベルが存在（AND条件）",
+			configLabels: "hoge-project,needs-review",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("hoge-project")},
+				{Name: github.Ptr("needs-review")},
+				{Name: github.Ptr("bug")},
+			},
+			expectedResult: true,
+		},
+		{
+			name:         "複数ラベル設定で一部ラベルのみ存在",
+			configLabels: "hoge-project,needs-review",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("hoge-project")},
+				{Name: github.Ptr("bug")},
+			},
+			expectedResult: false,
+		},
+		{
+			name:         "カンマ前後のスペースを適切に処理",
+			configLabels: "hoge-project , needs-review , bug",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("hoge-project")},
+				{Name: github.Ptr("needs-review")},
+				{Name: github.Ptr("bug")},
+				{Name: github.Ptr("feature")},
+			},
+			expectedResult: true,
+		},
+		{
+			name:           "空文字列の場合は全てマッチ（後方互換）",
+			configLabels:   "",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("any-label")},
+			},
+			expectedResult: true,
+		},
+		{
+			name:           "PRにラベルがない場合",
+			configLabels:   "needs-review",
+			prLabels:       []*github.Label{},
+			expectedResult: false,
+		},
+		{
+			name:           "設定が空でPRにもラベルがない",
+			configLabels:   "",
+			prLabels:       []*github.Label{},
+			expectedResult: true,
+		},
+		{
+			name:         "3つのラベル全てが必要な設定",
+			configLabels: "project-a,needs-review,urgent",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("project-a")},
+				{Name: github.Ptr("needs-review")},
+				{Name: github.Ptr("urgent")},
+				{Name: github.Ptr("bug")},
+			},
+			expectedResult: true,
+		},
+		{
+			name:         "3つのラベルのうち1つが不足",
+			configLabels: "project-a,needs-review,urgent",
+			prLabels: []*github.Label{
+				{Name: github.Ptr("project-a")},
+				{Name: github.Ptr("needs-review")},
+				{Name: github.Ptr("bug")},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &models.ChannelConfig{
+				LabelName: tt.configLabels,
+			}
+
+			result := IsLabelMatched(config, tt.prLabels)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
## 概要
GitHubのPRに複数のラベルが付いている場合に、全てのラベルが存在する場合のみ（AND条件）Slack通知を送信する機能を実装しました。従来の単一ラベル設定に加えて、カンマ区切りで複数ラベルを指定できるようになります。

### 変更内容
- **IsLabelMatched関数の追加** (services/config.go): カンマ区切りの複数ラベル設定でPRの全ラベルをチェックし、AND条件でマッチングを行う
- **handleLabeledEventの更新** (handlers/webhook.go): 従来の単純な文字列比較をIsLabelMatched関数に置き換え、複数ラベル対応を実現
- **ヘルプメッセージの更新** (handlers/command.go): 複数ラベルAND条件の設定方法について詳しい説明を追加
- **包括的なテストケース追加**:
  - services/label_matching_test.go: IsLabelMatched関数の単体テスト
  - handlers/webhook_test.go: TestMultipleLabelMatching関数追加
  - handlers/multiple_label_command_test.go: コマンドハンドラーのテスト

### 期待すること
- **より精密な通知制御**: プロジェクト固有のラベル（例：`hoge-project`）と汎用ラベル（例：`needs-review`）の組み合わせで、関連するチームのみに通知を送信できる
- **既存機能の完全な後方互換性**: 現在の単一ラベル設定はそのまま継続して動作
- **設定の柔軟性向上**: 複数のラベル条件を組み合わせることで、より細かい通知ルールを設定可能
- **GitHub API使用量の維持**: 新機能でもGitHub APIの追加呼び出しは発生せず、既存のWebhookデータのみを使用

