### PR TITLE
ラベル未設定の設定に対して全ラベルがマッチしてしまう問題を修正

### DIFF
--- a/services/config.go
+++ b/services/config.go
@@ -63,9 +63,10 @@ func IsLabelMatched(config *models.ChannelConfig, prLabels []*github.Label) bool
 		return false
 	}
 
-	// 空文字列の場合は全てマッチ（後方互換性）
+	// 空文字列の場合はマッチしない
 	if config.LabelName == "" {
-		return true
+		log.Printf("no label configured for channel")
+		return false
 	}
 
 	// PRのラベル名をセットに変換

--- a/services/label_matching_test.go
+++ b/services/label_matching_test.go
@@ -73,12 +73,12 @@ func TestIsLabelMatched(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "空文字列の場合は全てマッチ（後方互換）",
+			name:           "空文字列の場合はマッチしない",
 			configLabels:   "",
 			prLabels: []*github.Label{
 				{Name: github.Ptr("any-label")},
 			},
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			name:           "PRにラベルがない場合",
@@ -90,7 +90,7 @@ func TestIsLabelMatched(t *testing.T) {
 			name:           "設定が空でPRにもラベルがない",
 			configLabels:   "",
 			prLabels:       []*github.Label{},
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			name:         "3つのラベル全てが必要な設定",


### PR DESCRIPTION
## 概要
複数ラベル対応のリリース後、ラベル名が空文字列の設定が存在する場合、どのラベルが付いても通知が発火してしまう問題を修正しました。

### 変更内容
- `IsLabelMatched`関数で、`config.LabelName`が空文字列の場合は`false`を返すように変更
- 空文字列の場合の後方互換性を削除（全てマッチ → マッチしない）
- 関連するテストケースを修正し、空文字列の場合はマッチしないことを保証

### 期待すること
- ラベル名が設定されていない設定は、どのラベルが付いても通知されない
- 明示的に設定されたラベルのみが通知のトリガーとなる
- 意図しない通知の発火を防ぐ
