### PR TITLE
テスト用IsOutsideBusinessHours関数を削除し、IsWithinBusinessHoursに統一

### DIFF
--- a/services/slack.go
+++ b/services/slack.go
@@ -600,16 +600,6 @@ func SendReviewerChangedMessage(task models.ReviewTask, oldReviewerID string) er
 	return PostToThread(task.SlackChannel, task.SlackTS, message)
 }
 
-// IsOutsideBusinessHours は後方互換性のためのテスト専用関数
-// デフォルトの営業時間設定（10:00-19:00 JST）で営業時間外かどうかを判定
-func IsOutsideBusinessHours(t time.Time) bool {
-	defaultConfig := &models.ChannelConfig{
-		BusinessHoursStart: "10:00",
-		BusinessHoursEnd:   "19:00",
-		Timezone:           "Asia/Tokyo",
-	}
-	return !IsWithinBusinessHours(defaultConfig, t)
-}
 
 // 指定された時刻から翌営業日の営業開始時刻を取得する関数（営業時間設定対応）
 func GetNextBusinessDayMorningWithConfig(now time.Time, config *models.ChannelConfig) time.Time {


### PR DESCRIPTION
## 概要
後方互換性のためのテスト専用関数として残されていた`IsOutsideBusinessHours`を削除し、すべてのテストを`IsWithinBusinessHours`関数を使用するように統一しました。これにより、コードベースの一貫性が向上し、営業時間判定ロジックが単一の関数に集約されました。

### 変更内容
- `services/slack.go`: `IsOutsideBusinessHours`関数を削除
- `services/business_hours_integration_test.go`:
  - `IsOutsideBusinessHours`の呼び出しを`IsWithinBusinessHours`に変更（論理を反転）
  - テスト関数名を`TestIsWithinBusinessHoursEdgeCases`に変更
  - 期待値を営業時間内判定用に修正
- `services/out_of_hours_reminder_test.go`:
  - `IsOutsideBusinessHours`の呼び出しを`IsWithinBusinessHours`に変更（論理を反転）
  - テスト関数名を`TestIsWithinBusinessHours_DefaultConfig`に変更
  - 期待値を営業時間内判定用に修正

### 期待すること
- コードベースの一貫性が向上し、保守性が高まる
- 営業時間判定ロジックが単一の関数に集約されることで、バグの可能性が減少
- テストコードがより明確で理解しやすくなる
- 将来的な営業時間関連機能の拡張が容易になる

