### PR TITLE
Slackメッセージ内のメンション表記を <@user> から @user 形式に変更

### DIFF
--- a/handlers/slack.go
+++ b/handlers/slack.go
@@ -196,7 +196,7 @@ func HandleSlackAction(db *gorm.DB) gin.HandlerFunc {
 			}
 
 			// レビュー完了通知をスレッドに投稿
-			message := fmt.Sprintf("✅ <@%s> さんがレビューを完了しました！感謝！👏", slackUserID)
+			message := fmt.Sprintf("✅ @%s さんがレビューを完了しました！感謝！👏", slackUserID)
 			if err := services.PostToThread(task.SlackChannel, task.SlackTS, message); err != nil {
 				log.Printf("review done notification error: %v", err)
 			}

--- a/services/slack.go
+++ b/services/slack.go
@@ -182,7 +182,7 @@ func PostBusinessHoursNotificationToThread(task models.ReviewTask, mentionID str
 	// レビュワーが設定されている場合は追加
 	var reviewerText string
 	if task.Reviewer != "" {
-		reviewerText = fmt.Sprintf("\n\n🎯 *レビュワー*: <@%s> さん、よろしくお願いします！", task.Reviewer)
+		reviewerText = fmt.Sprintf("\n\n🎯 *レビュワー*: @%s さん、よろしくお願いします！", task.Reviewer)
 	}
 
 	message := fmt.Sprintf("🌅 *おはようございます！* %s\n\n📋 こちらのPRのレビューをお願いします。%s", mentionText, reviewerText)
@@ -413,7 +413,7 @@ func SendReviewerReminderMessage(db *gorm.DB, task models.ReviewTask) error {
 		return fmt.Errorf("channel is archived: %s", task.SlackChannel)
 	}
 
-	message := fmt.Sprintf("<@%s> レビューしてくれたら嬉しいです...👀", task.Reviewer)
+	message := fmt.Sprintf("@%s レビューしてくれたら嬉しいです...👀", task.Reviewer)
 
 	pauseSelect := CreateAllOptionsPauseReminderSelect(task.ID, "pause_reminder", "リマインダーを停止")
 	blocks := CreateMessageWithActionBlocks(message, pauseSelect)
@@ -563,7 +563,7 @@ func IsChannelArchived(channelID string) (bool, error) {
 
 // 自動割り当てされたレビュワーを表示し、変更ボタンを表示する関数
 func PostReviewerAssignedMessageWithChangeButton(task models.ReviewTask) error {
-	message := fmt.Sprintf("自動でレビュワーが割り当てられました: <@%s> レビューをお願いします！", task.Reviewer)
+	message := fmt.Sprintf("自動でレビュワーが割り当てられました: @%s レビューをお願いします！", task.Reviewer)
 
 	changeButton := CreateChangeReviewerButton(task.ID)
 	pauseSelect := CreateAllOptionsPauseReminderSelect(task.ID, "pause_reminder_initial", "リマインダーを停止")
@@ -673,7 +673,7 @@ func GetNextBusinessDayMorningWithConfig(now time.Time, config *models.ChannelCo
 
 // SendOutOfHoursReminderMessage は営業時間外のリマインドメッセージを送信する
 func SendOutOfHoursReminderMessage(db *gorm.DB, task models.ReviewTask) error {
-	message := fmt.Sprintf("<@%s> レビューしてくれたら嬉しいです...👀\n\n営業時間外のため、次回のリマインドは翌営業日に送信します。", task.Reviewer)
+	message := fmt.Sprintf("@%s レビューしてくれたら嬉しいです...👀\n\n営業時間外のため、次回のリマインドは翌営業日に送信します。", task.Reviewer)
 
 	pauseSelect := CreateStopOnlyPauseReminderSelect(task.ID, "pause_reminder", "リマインダーを停止")
 	blocks := CreateMessageWithActionBlocks(message, pauseSelect)


### PR DESCRIPTION
## 概要
Slackメッセージ内でユーザーメンションが `<@user>` のように山括弧で囲まれて表示される問題を修正しました。メンション形式を `@user` に変更することで、より自然な表示になります。

### 変更内容
- **services/slack.go**
  - `PostBusinessHoursNotificationToThread`: レビュワー表示を `<@%s>` → `@%s` に変更 (185行目)
  - `SendReviewerReminderMessage`: リマインダーメッセージを `<@%s>` → `@%s` に変更 (416行目)
  - `PostReviewerAssignedMessageWithChangeButton`: レビュワー割り当てメッセージを `<@%s>` → `@%s` に変更 (566行目)
  - `SendOutOfHoursReminderMessage`: 営業時間外リマインダーを `<@%s>` → `@%s` に変更 (676行目)

- **handlers/slack.go**
  - `HandleSlackAction`: レビュー完了通知を `<@%s>` → `@%s` に変更 (199行目)


