### PR TITLE
複数レビュワーに対応

### DIFF
--- a/services/slack.go
+++ b/services/slack.go
@@ -594,9 +594,33 @@ func PostReviewerAssignedMessageWithChangeButton(task models.ReviewTask) error {
 	return nil
 }
 
+// formatReviewerMentions は複数のレビュワーIDをSlackメンション形式に変換する
+func formatReviewerMentions(reviewerIDs string) string {
+	if reviewerIDs == "" {
+		return ""
+	}
+
+	// スペースで分割してIDを抽出
+	ids := strings.Fields(reviewerIDs)
+
+	var mentions []string
+	for _, id := range ids {
+		// @記号を取り除く
+		cleanID := strings.TrimPrefix(id, "@")
+		if cleanID != "" {
+			mentions = append(mentions, fmt.Sprintf("<@%s>", cleanID))
+		}
+	}
+
+	return strings.Join(mentions, " ")
+}
+
 // レビュワーが変更されたことを通知する関数
 func SendReviewerChangedMessage(task models.ReviewTask, oldReviewerID string) error {
-	message := fmt.Sprintf("レビュワーを変更しました: <@%s> → <@%s> さん、よろしくお願いします！", oldReviewerID, task.Reviewer)
+	oldMentions := formatReviewerMentions(oldReviewerID)
+	newMentions := formatReviewerMentions(task.Reviewer)
+
+	message := fmt.Sprintf("レビュワーを変更しました: %s → %s さん、よろしくお願いします！", oldMentions, newMentions)
 	return PostToThread(task.SlackChannel, task.SlackTS, message)
 }
 

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -647,3 +647,55 @@ func TestSendReviewCompletedAutoNotification(t *testing.T) {
 		})
 	}
 }
+
+// TestFormatReviewerMentions は複数のレビュワーIDをSlackメンション形式に変換する関数のテスト
+func TestFormatReviewerMentions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "単一レビュワーID",
+			input:    "haruotsu",
+			expected: "<@haruotsu>",
+		},
+		{
+			name:     "複数レビュワーID（スペース区切り）",
+			input:    "kitkatayama @uchimura",
+			expected: "<@kitkatayama> <@uchimura>",
+		},
+		{
+			name:     "複数レビュワーID（@付き）",
+			input:    "@nakamu @shunhamm",
+			expected: "<@nakamu> <@shunhamm>",
+		},
+		{
+			name:     "混在パターン",
+			input:    "nakamu @haruotsu",
+			expected: "<@nakamu> <@haruotsu>",
+		},
+		{
+			name:     "空文字列",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "3人のレビュワー",
+			input:    "user1 @user2 @user3",
+			expected: "<@user1> <@user2> <@user3>",
+		},
+		{
+			name:     "余分なスペース",
+			input:    "  user1   @user2  ",
+			expected: "<@user1> <@user2>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := formatReviewerMentions(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## 概要
レビュワー変更メッセージにおいて、複数のレビュワーIDがスペース区切りで保存されている場合に正しくメンションできない問題を修正しました。従来は `@hoge @piyo` のような複数IDを含む文字列を単純に `<@hoge @piyo>` としていたため、Slackでメンションとして認識されませんでしたが、今回の修正により `<@hoge> <@piyo>` のように個別のメンション形式に変換されるようになりました。

### 変更内容
- `formatReviewerMentions` 関数を新規追加（services/slack.go:597-618）
  - スペース区切りの複数レビュワーIDを個別のSlackメンション形式に変換
  - `@` 記号の有無にも対応
  - 余分なスペースも適切に処理
- `SendReviewerChangedMessage` 関数を修正（services/slack.go:621-627）
  - `formatReviewerMentions` を使用して旧レビュワーと新レビュワーを正しくメンション形式に変換
- テストケースを追加（services/slack_test.go:651-701）
  - 単一レビュワー、複数レビュワー、@付き、混在パターン、空文字列、余分なスペースなど7つのテストケース

### 期待すること
- 複数のレビュワーを登録している場合でも、レビュワー変更時に全員に正しく通知が届くようになる
- ユーザーは複数レビュワーの運用を継続でき、全員が適切にメンションされる
- 単一レビュワーの場合も従来通り動作する
- 既存機能への影響がない
