### PR TITLE
PRクローズ通知の追加とクローズ済みPRへのレビュー通知抑止

### DIFF
--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -39,12 +39,18 @@ func HandleGitHubWebhook(db *gorm.DB) gin.HandlerFunc {
 		switch e := event.(type) {
 		case *github.PullRequestEvent:
 			log.Printf("PullRequestEvent received: action=%s", e.GetAction())
-			if e.Action != nil && e.Label != nil {
+			if e.Action != nil {
 				switch *e.Action {
 				case "labeled":
-					handleLabeledEvent(c, db, e)
+					if e.Label != nil {
+						handleLabeledEvent(c, db, e)
+					}
 				case "unlabeled":
-					handleUnlabeledEvent(c, db, e)
+					if e.Label != nil {
+						handleUnlabeledEvent(c, db, e)
+					}
+				case "closed":
+					handleClosedEvent(c, db, e)
 				}
 			}
 		case *github.PullRequestReviewEvent:
@@ -358,6 +364,44 @@ func handleUnlabeledEvent(c *gin.Context, db *gorm.DB, e *github.PullRequestEven
 	}
 }
 
+// PRがcloseされた際の処理
+func handleClosedEvent(c *gin.Context, db *gorm.DB, e *github.PullRequestEvent) {
+	pr := e.PullRequest
+	repo := e.Repo
+	repoFullName := fmt.Sprintf("%s/%s", repo.GetOwner().GetLogin(), repo.GetName())
+
+	log.Printf("handling closed event: repo=%s, pr=%d, merged=%v", repoFullName, pr.GetNumber(), pr.GetMerged())
+
+	// 該当するPRの全てのアクティブタスクを検索
+	var tasks []models.ReviewTask
+	db.Where("repo = ? AND pr_number = ? AND status IN (?)",
+		repoFullName, pr.GetNumber(), []string{"pending", "in_review", "snoozed", "waiting_business_hours"}).Find(&tasks)
+
+	if len(tasks) == 0 {
+		log.Printf("no active tasks found for closed event: repo=%s, pr=%d", repoFullName, pr.GetNumber())
+		return
+	}
+
+	// 各タスクについて完了処理を実行
+	for _, task := range tasks {
+		// Slackにクローズ通知を送信
+		if err := services.PostPRClosedNotification(task, pr.GetMerged()); err != nil {
+			log.Printf("failed to post PR closed notification: %v", err)
+			// 通知失敗してもタスクは完了状態にする
+		}
+
+		// タスクのステータスを完了に更新
+		task.Status = "completed"
+		task.UpdatedAt = time.Now()
+		if err := db.Save(&task).Error; err != nil {
+			log.Printf("failed to update task status to completed: %v", err)
+			continue
+		}
+
+		log.Printf("task completed due to PR closed: id=%s, repo=%s, pr=%d, merged=%v",
+			task.ID, repoFullName, pr.GetNumber(), pr.GetMerged())
+	}
+}
 
 // レビューが提出された際の処理
 func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullRequestReviewEvent) {
@@ -368,6 +412,12 @@ func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 
 	log.Printf("handling review submitted event: repo=%s, pr=%d, reviewer=%s, state=%s",
 		repoFullName, pr.GetNumber(), review.GetUser().GetLogin(), review.GetState())
+
+	// PRが閉じている場合は通知をスキップ
+	if pr.GetState() == "closed" {
+		log.Printf("PR is closed, skipping notification: repo=%s, pr=%d", repoFullName, pr.GetNumber())
+		return
+	}
 
 	// レビューが「承認」「変更要求」「コメント」のいずれかの場合のみ処理
 	reviewState := review.GetState()

--- a/services/slack.go
+++ b/services/slack.go
@@ -824,3 +824,20 @@ func PostLabelRemovedNotification(task models.ReviewTask, removedLabels []string
 
 	return PostToThread(task.SlackChannel, task.SlackTS, message)
 }
+
+// PostPRClosedNotification は、PRがcloseされたことをスレッドに通知する
+func PostPRClosedNotification(task models.ReviewTask, merged bool) error {
+	if IsTestMode {
+		log.Printf("test mode: would post PR closed notification for task: %s (merged: %v)", task.ID, merged)
+		return nil
+	}
+
+	var message string
+	if merged {
+		message = "🎉 PRがマージされました！お疲れさまでした！"
+	} else {
+		message = "🔒 PRがクローズされました。"
+	}
+
+	return PostToThread(task.SlackChannel, task.SlackTS, message)
+}


### PR DESCRIPTION
 ## Summary

  - PRがcloseされた際に、Slackスレッドに完了通知を送信する機能を追加
  - closeされたPRへのレビューコメントは通知を送信しないように変更

  ## Changes

  ### 1. PRクローズイベントのハンドリング追加
  - `handlers/webhook.go`: `closed` アクションを処理するように修正
  - `handleClosedEvent` 関数を新規追加し、アクティブなタスクを完了状態に更新

  ### 2. Slack通知機能の追加
  - `services/slack.go`: `PostPRClosedNotification` 関数を追加
    - マージされた場合: 🎉 「PRがマージされました！お疲れさまでした！」
    - クローズのみの場合: 🔒 「PRがクローズされました。」

  ### 3. closeされたPRへのレビュー通知を抑止
  - `handlers/webhook.go`: `handleReviewSubmittedEvent` で PR の状態が `closed` の場合は早期リターン

## 関連issue
- https://github.com/haruotsu/slack-review-notify/issues/15
