### PR TITLE
change default language from ja to en

### DIFF
--- a/models/channel_config.go
+++ b/models/channel_config.go
@@ -20,7 +20,7 @@ type ChannelConfig struct {
 	BusinessHoursStart       string `gorm:"default:'09:00'"`      // Business hours start (HH:MM format)
 	BusinessHoursEnd         string `gorm:"default:'18:00'"`      // Business hours end (HH:MM format)
 	Timezone                 string `gorm:"default:'Asia/Tokyo'"` // Timezone (default: JST)
-	Language                 string `gorm:"default:'ja'"`         // Language for messages (ja, en)
+	Language                 string `gorm:"default:'en'"`         // Language for messages (ja, en)
 	CreatedAt                time.Time
 	UpdatedAt                time.Time
 	DeletedAt                gorm.DeletedAt `gorm:"index"`


### PR DESCRIPTION
デフォルト言語をjaからenに変更します。

## 変更内容
- `models/channel_config.go` の `Language` フィールドのGORMデフォルト値を `ja` から `en` に変更

## 影響範囲
- 既存のチャンネル設定には影響なし（DBに保存済みのレコードはそのまま）
- この変更後に新規作成されるチャンネル設定のデフォルト言語が `en` になる