### PR TITLE
レビュー再リクエスト時に、タスクのReviewers/ApprovedByを更新する機能の追加

### DIFF
--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -528,6 +528,31 @@ func handleReviewRequestedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 			log.Printf("task reactivated for re-review: id=%s, repo=%s, pr=%d", latestTask.ID, repoFullName, pr.GetNumber())
 		}
 
+		// Update Reviewers list: add re-requested reviewer and remove their approval
+		if reviewerSlackID != "" {
+			updates := map[string]interface{}{
+				"updated_at": time.Now(),
+			}
+
+			// Add reviewer to Reviewers list if not already present
+			if services.AddReviewer(&latestTask, reviewerSlackID) {
+				updates["reviewers"] = latestTask.Reviewers
+				log.Printf("added reviewer %s to task reviewers: id=%s", reviewerSlackID, latestTask.ID)
+			}
+
+			// Remove from ApprovedBy if previously approved (re-request means new review needed)
+			if services.RemoveApproval(&latestTask, reviewerSlackID) {
+				updates["approved_by"] = latestTask.ApprovedBy
+				log.Printf("removed approval from %s for re-review: id=%s", reviewerSlackID, latestTask.ID)
+			}
+
+			if len(updates) > 1 { // more than just updated_at
+				if err := db.Model(&models.ReviewTask{}).Where("id = ?", latestTask.ID).Updates(updates).Error; err != nil {
+					log.Printf("failed to update reviewers for re-review: %v", err)
+				}
+			}
+		}
+
 		// Post re-review request notification to thread
 		t := i18n.L(latestTask.Language)
 		message := t("notify.re_review_requested", senderMention, reviewerMention)

--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -546,10 +546,8 @@ func handleReviewRequestedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 				log.Printf("removed approval from %s for re-review: id=%s", reviewerSlackID, latestTask.ID)
 			}
 
-			if len(updates) > 1 { // more than just updated_at
-				if err := db.Model(&models.ReviewTask{}).Where("id = ?", latestTask.ID).Updates(updates).Error; err != nil {
-					log.Printf("failed to update reviewers for re-review: %v", err)
-				}
+			if err := db.Model(&models.ReviewTask{}).Where("id = ?", latestTask.ID).Updates(updates).Error; err != nil {
+				log.Printf("failed to update reviewers for re-review: %v", err)
 			}
 		}
 

--- a/handlers/webhook_test.go
+++ b/handlers/webhook_test.go
@@ -1950,6 +1950,183 @@ func TestHandleReviewRequestedEvent_InReviewTask(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Re-request notification should be sent to Slack")
 }
 
+func TestHandleReviewRequestedEvent_UpdatesReviewers(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	defer gock.Off()
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// Create user mapping for the re-requested reviewer
+	db.Create(&models.UserMapping{
+		ID:             "mapping-1",
+		GithubUsername: "new-reviewer",
+		SlackUserID:    "UNEW",
+	})
+
+	// Create in_review task with existing reviewers
+	task := models.ReviewTask{
+		ID:           "reviewers-update-task",
+		PRURL:        "https://github.com/owner/repo/pull/400",
+		Repo:         "owner/repo",
+		PRNumber:     400,
+		Title:        "Test PR",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewers:    "UOLD1,UOLD2",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "review_requested",
+		"pull_request": {"number": 400, "html_url": "https://github.com/owner/repo/pull/400"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"sender": {"login": "author"},
+		"requested_reviewer": {"login": "new-reviewer"}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Reviewer should be added to Reviewers list
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "reviewers-update-task").First(&updatedTask)
+	assert.Equal(t, "UOLD1,UOLD2,UNEW", updatedTask.Reviewers)
+}
+
+func TestHandleReviewRequestedEvent_RemovesApprovalOnReRequest(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	defer gock.Off()
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// Create user mapping
+	db.Create(&models.UserMapping{
+		ID:             "mapping-2",
+		GithubUsername: "approved-reviewer",
+		SlackUserID:    "UAPPROVED",
+	})
+
+	// Create task where reviewer already approved
+	task := models.ReviewTask{
+		ID:           "approval-reset-task",
+		PRURL:        "https://github.com/owner/repo/pull/401",
+		Repo:         "owner/repo",
+		PRNumber:     401,
+		Title:        "Test PR",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewers:    "UAPPROVED,UOTHER",
+		ApprovedBy:   "UAPPROVED",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "review_requested",
+		"pull_request": {"number": 401, "html_url": "https://github.com/owner/repo/pull/401"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"sender": {"login": "author"},
+		"requested_reviewer": {"login": "approved-reviewer"}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Approval should be removed (re-request means new review needed)
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "approval-reset-task").First(&updatedTask)
+	assert.Equal(t, "", updatedTask.ApprovedBy)
+	// Reviewers should remain unchanged (already present)
+	assert.Equal(t, "UAPPROVED,UOTHER", updatedTask.Reviewers)
+}
+
+func TestHandleReviewRequestedEvent_NoMappingSkipsReviewerUpdate(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	defer gock.Off()
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// No user mapping created - reviewer has no Slack mapping
+
+	task := models.ReviewTask{
+		ID:           "no-mapping-task",
+		PRURL:        "https://github.com/owner/repo/pull/402",
+		Repo:         "owner/repo",
+		PRNumber:     402,
+		Title:        "Test PR",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewers:    "UOLD1",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "review_requested",
+		"pull_request": {"number": 402, "html_url": "https://github.com/owner/repo/pull/402"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"sender": {"login": "author"},
+		"requested_reviewer": {"login": "unknown-reviewer"}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Reviewers should remain unchanged when no mapping exists
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "no-mapping-task").First(&updatedTask)
+	assert.Equal(t, "UOLD1", updatedTask.Reviewers)
+}
+
 func TestHandleReviewSubmittedEvent_DismissedOnlyUpdatesApprovedBy(t *testing.T) {
 	db := setupTestDB(t)
 	gin.SetMode(gin.TestMode)

--- a/services/slack.go
+++ b/services/slack.go
@@ -272,6 +272,24 @@ func RemoveApproval(task *models.ReviewTask, slackUserID string) bool {
 	return true
 }
 
+// AddReviewer adds a reviewer to task.Reviewers (preventing duplicates). Returns true if newly added
+func AddReviewer(task *models.ReviewTask, slackUserID string) bool {
+	if slackUserID == "" {
+		return false
+	}
+
+	if isInCSV(task.Reviewers, slackUserID) {
+		return false
+	}
+
+	if task.Reviewers != "" {
+		task.Reviewers = task.Reviewers + "," + slackUserID
+	} else {
+		task.Reviewers = slackUserID
+	}
+	return true
+}
+
 // CountApprovals returns the number of approvals in task.ApprovedBy
 func CountApprovals(task models.ReviewTask) int {
 	if task.ApprovedBy == "" {

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -974,3 +974,29 @@ func TestSelectRandomReviewers_ExcludesAwayUsers(t *testing.T) {
 		}
 	}
 }
+
+func TestAddReviewer(t *testing.T) {
+	t.Run("adds reviewer to empty Reviewers", func(t *testing.T) {
+		task := models.ReviewTask{Reviewers: ""}
+		assert.True(t, AddReviewer(&task, "U1"))
+		assert.Equal(t, "U1", task.Reviewers)
+	})
+
+	t.Run("adds reviewer to existing Reviewers", func(t *testing.T) {
+		task := models.ReviewTask{Reviewers: "U1,U2"}
+		assert.True(t, AddReviewer(&task, "U3"))
+		assert.Equal(t, "U1,U2,U3", task.Reviewers)
+	})
+
+	t.Run("does not add duplicate reviewer", func(t *testing.T) {
+		task := models.ReviewTask{Reviewers: "U1,U2"}
+		assert.False(t, AddReviewer(&task, "U2"))
+		assert.Equal(t, "U1,U2", task.Reviewers)
+	})
+
+	t.Run("returns false for empty slackUserID", func(t *testing.T) {
+		task := models.ReviewTask{Reviewers: "U1"}
+		assert.False(t, AddReviewer(&task, ""))
+		assert.Equal(t, "U1", task.Reviewers)
+	})
+}


### PR DESCRIPTION
レビュー再リクエスト時に、タスクのReviewers/ApprovedByを更新する機能の追加。

### 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `handlers/webhook.go` | re-request時にレビュワー追加＋承認取り消しロジック追加 |
| `services/slack.go` | `AddReviewer()` 関数の新規追加 |
| `handlers/webhook_test.go` | 3テストケース追加（レビュワー追加、承認取消、マッピングなし） |
| `services/slack_test.go` | `AddReviewer` のユニットテスト4ケース追加 |

