### PR TITLE
「変わってほしい」ボタンで休暇中レビュワーも同時に再抽選する

### DIFF
--- a/handlers/slack.go
+++ b/handlers/slack.go
@@ -313,9 +313,17 @@ func HandleSlackAction(db *gorm.DB) gin.HandlerFunc {
 			}
 
 			// Build a mapping of old -> new reviewer replacements
-			newIdx := 0
+			// Assign explicit replacement first to ensure deterministic mapping
 			replacementMap := make(map[string]string) // old ID -> new ID
+			newIdx := 0
+			if newIdx < len(newReviewerIDs) {
+				replacementMap[explicitReplace] = newReviewerIDs[newIdx]
+				newIdx++
+			}
 			for oldID := range replaceSet {
+				if oldID == explicitReplace {
+					continue
+				}
 				if newIdx < len(newReviewerIDs) {
 					replacementMap[oldID] = newReviewerIDs[newIdx]
 					newIdx++

--- a/handlers/slack.go
+++ b/handlers/slack.go
@@ -240,23 +240,54 @@ func HandleSlackAction(db *gorm.DB) gin.HandlerFunc {
 				db.Save(&taskToUpdate)
 			}
 
-			// Exclusions: PR author + other current reviewers
+			// Build the set of reviewers to replace:
+			// 1. The explicitly clicked reviewer (replacingReviewerID or taskToUpdate.Reviewer)
+			// 2. Any other current reviewers who are now away
+			awayIDs := services.GetAwayUserIDs(db)
+			awaySet := make(map[string]bool)
+			for _, id := range awayIDs {
+				if id != "" {
+					awaySet[id] = true
+				}
+			}
+
+			// Determine which reviewer was explicitly requested to replace
+			explicitReplace := replacingReviewerID
+			if explicitReplace == "" {
+				explicitReplace = taskToUpdate.Reviewer
+			}
+
+			// Collect all reviewer IDs that need replacement (explicit + away)
+			replaceSet := make(map[string]bool)
+			replaceSet[explicitReplace] = true
+
+			var currentReviewerList []string
+			if taskToUpdate.Reviewers != "" {
+				for _, id := range strings.Split(taskToUpdate.Reviewers, ",") {
+					if trimmed := strings.TrimSpace(id); trimmed != "" {
+						currentReviewerList = append(currentReviewerList, trimmed)
+						if awaySet[trimmed] {
+							replaceSet[trimmed] = true
+						}
+					}
+				}
+			} else if taskToUpdate.Reviewer != "" {
+				currentReviewerList = []string{taskToUpdate.Reviewer}
+			}
+
+			replacementCount := len(replaceSet)
+
+			// Exclusions: PR author + all current reviewers (including those being replaced)
 			excludeIDs := []string{}
 			if taskToUpdate.PRAuthorSlackID != "" {
 				excludeIDs = append(excludeIDs, taskToUpdate.PRAuthorSlackID)
 			}
-			if taskToUpdate.Reviewers != "" {
-				for _, id := range strings.Split(taskToUpdate.Reviewers, ",") {
-					if trimmed := strings.TrimSpace(id); trimmed != "" {
-						excludeIDs = append(excludeIDs, trimmed)
-					}
-				}
-			} else if taskToUpdate.Reviewer != "" {
-				excludeIDs = append(excludeIDs, taskToUpdate.Reviewer)
+			for _, id := range currentReviewerList {
+				excludeIDs = append(excludeIDs, id)
 			}
 
-			// Select one new reviewer
-			newReviewerIDs := services.SelectRandomReviewers(db, taskToUpdate.SlackChannel, taskToUpdate.LabelName, 1, excludeIDs)
+			// Select enough new reviewers to replace all
+			newReviewerIDs := services.SelectRandomReviewers(db, taskToUpdate.SlackChannel, taskToUpdate.LabelName, replacementCount, excludeIDs)
 
 			// No real candidates if SelectRandomReviewers only returned DefaultMentionID
 			noRealCandidate := false
@@ -280,50 +311,61 @@ func HandleSlackAction(db *gorm.DB) gin.HandlerFunc {
 				c.Status(http.StatusOK)
 				return
 			}
-			newReviewerID := newReviewerIDs[0]
 
-			// Save the old reviewer ID
-			oldReviewerID := taskToUpdate.Reviewer
-
-			// Update the Reviewers field
-			if replacingReviewerID != "" && taskToUpdate.Reviewers != "" {
-				// Replace a specific reviewer
-				var updatedReviewers []string
-				for _, id := range strings.Split(taskToUpdate.Reviewers, ",") {
-					trimmed := strings.TrimSpace(id)
-					if trimmed == replacingReviewerID {
-						updatedReviewers = append(updatedReviewers, newReviewerID)
-					} else {
-						updatedReviewers = append(updatedReviewers, trimmed)
-					}
-				}
-				taskToUpdate.Reviewers = strings.Join(updatedReviewers, ",")
-				oldReviewerID = replacingReviewerID
-			} else {
-				// Backward compatibility: single reviewer change
-				if taskToUpdate.Reviewers != "" {
-					var updatedReviewers []string
-					for _, id := range strings.Split(taskToUpdate.Reviewers, ",") {
-						trimmed := strings.TrimSpace(id)
-						if trimmed == taskToUpdate.Reviewer {
-							updatedReviewers = append(updatedReviewers, newReviewerID)
-						} else {
-							updatedReviewers = append(updatedReviewers, trimmed)
-						}
-					}
-					taskToUpdate.Reviewers = strings.Join(updatedReviewers, ",")
+			// Build a mapping of old -> new reviewer replacements
+			newIdx := 0
+			replacementMap := make(map[string]string) // old ID -> new ID
+			for oldID := range replaceSet {
+				if newIdx < len(newReviewerIDs) {
+					replacementMap[oldID] = newReviewerIDs[newIdx]
+					newIdx++
 				}
 			}
 
-			// Update the Reviewer field (backward compatibility)
-			taskToUpdate.Reviewer = newReviewerID
+			// Save the old reviewer ID for notification
+			oldReviewerID := taskToUpdate.Reviewer
+			if replacingReviewerID != "" {
+				oldReviewerID = replacingReviewerID
+			}
+
+			// Update the Reviewers field by replacing all matched reviewers
+			if len(currentReviewerList) > 0 {
+				var updatedReviewers []string
+				for _, id := range currentReviewerList {
+					if newID, ok := replacementMap[id]; ok {
+						updatedReviewers = append(updatedReviewers, newID)
+					} else {
+						updatedReviewers = append(updatedReviewers, id)
+					}
+				}
+				taskToUpdate.Reviewers = strings.Join(updatedReviewers, ",")
+			}
+
+			// Update the Reviewer field (backward compatibility): use the replacement for the explicit one
+			if newID, ok := replacementMap[explicitReplace]; ok {
+				taskToUpdate.Reviewer = newID
+			} else if len(newReviewerIDs) > 0 {
+				taskToUpdate.Reviewer = newReviewerIDs[0]
+			}
+
 			taskToUpdate.UpdatedAt = time.Now()
 			db.Save(&taskToUpdate)
 
-			// Notify that the reviewer has been changed
+			// Notify that the reviewer has been changed (for the explicit replacement)
 			err := services.SendReviewerChangedMessage(taskToUpdate, oldReviewerID)
 			if err != nil {
 				log.Printf("reviewer change notification error: %v", err)
+			}
+
+			// Notify for each additional away reviewer that was replaced
+			for oldID, newID := range replacementMap {
+				if oldID != explicitReplace {
+					awayTask := taskToUpdate
+					awayTask.Reviewer = newID
+					if notifyErr := services.SendReviewerChangedMessage(awayTask, oldID); notifyErr != nil {
+						log.Printf("away reviewer change notification error: %v", notifyErr)
+					}
+				}
 			}
 
 			c.Status(http.StatusOK)

--- a/handlers/slack.go
+++ b/handlers/slack.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -320,10 +321,15 @@ func HandleSlackAction(db *gorm.DB) gin.HandlerFunc {
 				replacementMap[explicitReplace] = newReviewerIDs[newIdx]
 				newIdx++
 			}
+			// Sort remaining IDs for deterministic assignment
+			var remainingOldIDs []string
 			for oldID := range replaceSet {
-				if oldID == explicitReplace {
-					continue
+				if oldID != explicitReplace {
+					remainingOldIDs = append(remainingOldIDs, oldID)
 				}
+			}
+			sort.Strings(remainingOldIDs)
+			for _, oldID := range remainingOldIDs {
 				if newIdx < len(newReviewerIDs) {
 					replacementMap[oldID] = newReviewerIDs[newIdx]
 					newIdx++

--- a/handlers/slack_reviewer_test.go
+++ b/handlers/slack_reviewer_test.go
@@ -605,3 +605,200 @@ func TestHandleSlackAction_ChangeReviewer_AlsoReplacesAwayReviewers(t *testing.T
 			"new reviewers should be from available candidates")
 	}
 }
+
+// Test that non-away reviewers are NOT replaced (only the clicked one is)
+func TestHandleSlackAction_ChangeReviewer_NoAwayReviewers(t *testing.T) {
+	services.IsTestMode = true
+	defer func() { services.IsTestMode = false }()
+
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/slack/action", HandleSlackAction(db))
+
+	config := models.ChannelConfig{
+		ID:               "config-noaway-1",
+		SlackChannelID:   "C12345",
+		LabelName:        "needs-review",
+		DefaultMentionID: "U00000",
+		ReviewerList:     "U11111,U22222,U33333,U44444",
+		IsActive:         true,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+	db.Create(&config)
+
+	// Task with 2 reviewers, neither is away
+	task := models.ReviewTask{
+		ID:           "test-task-noaway-1",
+		PRURL:        "https://github.com/test/repo/pull/30",
+		Repo:         "test/repo",
+		PRNumber:     30,
+		Title:        "Test PR No Away",
+		SlackTS:      "6666.1111",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewer:     "U11111",
+		Reviewers:    "U11111,U22222",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	payload := SlackActionPayload{
+		Type: "block_actions",
+		User: struct {
+			ID string `json:"id"`
+		}{ID: "U99999"},
+		Actions: []struct {
+			ActionID       string `json:"action_id"`
+			Value          string `json:"value,omitempty"`
+			SelectedOption struct {
+				Value string `json:"value"`
+				Text  struct {
+					Text string `json:"text"`
+				} `json:"text"`
+			} `json:"selected_option,omitempty"`
+		}{
+			{
+				ActionID: "change_reviewer",
+				Value:    "test-task-noaway-1:U11111",
+			},
+		},
+		Container: struct {
+			ChannelID string `json:"channel_id"`
+		}{ChannelID: "C12345"},
+		Message: struct {
+			Ts string `json:"ts"`
+		}{Ts: "6666.1111"},
+	}
+
+	payloadJSON, _ := json.Marshal(payload)
+	form := url.Values{}
+	form.Add("payload", string(payloadJSON))
+
+	req := httptest.NewRequest("POST", "/slack/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "test-task-noaway-1").First(&updatedTask)
+
+	reviewerIDs := strings.Split(updatedTask.Reviewers, ",")
+	assert.Equal(t, 2, len(reviewerIDs), "should still have 2 reviewers")
+
+	// U11111 (clicked) should be replaced, U22222 (not away) should remain
+	assert.NotEqual(t, "U11111", strings.TrimSpace(reviewerIDs[0]),
+		"U11111 should be replaced")
+	assert.Equal(t, "U22222", strings.TrimSpace(reviewerIDs[1]),
+		"U22222 should remain (not away)")
+}
+
+// Test partial replacement when not enough candidates for all away reviewers
+func TestHandleSlackAction_ChangeReviewer_PartialReplacementWhenCandidatesInsufficient(t *testing.T) {
+	services.IsTestMode = true
+	defer func() { services.IsTestMode = false }()
+
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/slack/action", HandleSlackAction(db))
+
+	// Only 3 reviewers total, 2 assigned, need to replace 2 but only 1 candidate left
+	config := models.ChannelConfig{
+		ID:               "config-partial-1",
+		SlackChannelID:   "C12345",
+		LabelName:        "needs-review",
+		DefaultMentionID: "U00000",
+		ReviewerList:     "U11111,U22222,U33333",
+		IsActive:         true,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+	db.Create(&config)
+
+	task := models.ReviewTask{
+		ID:           "test-task-partial-1",
+		PRURL:        "https://github.com/test/repo/pull/40",
+		Repo:         "test/repo",
+		PRNumber:     40,
+		Title:        "Test PR Partial",
+		SlackTS:      "7777.1111",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewer:     "U11111",
+		Reviewers:    "U11111,U22222",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	// U22222 is away
+	away := models.ReviewerAvailability{
+		ID:          "away-partial-1",
+		SlackUserID: "U22222",
+		AwayUntil:   nil,
+		Reason:      "vacation",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	db.Create(&away)
+
+	payload := SlackActionPayload{
+		Type: "block_actions",
+		User: struct {
+			ID string `json:"id"`
+		}{ID: "U99999"},
+		Actions: []struct {
+			ActionID       string `json:"action_id"`
+			Value          string `json:"value,omitempty"`
+			SelectedOption struct {
+				Value string `json:"value"`
+				Text  struct {
+					Text string `json:"text"`
+				} `json:"text"`
+			} `json:"selected_option,omitempty"`
+		}{
+			{
+				ActionID: "change_reviewer",
+				Value:    "test-task-partial-1:U11111",
+			},
+		},
+		Container: struct {
+			ChannelID string `json:"channel_id"`
+		}{ChannelID: "C12345"},
+		Message: struct {
+			Ts string `json:"ts"`
+		}{Ts: "7777.1111"},
+	}
+
+	payloadJSON, _ := json.Marshal(payload)
+	form := url.Values{}
+	form.Add("payload", string(payloadJSON))
+
+	req := httptest.NewRequest("POST", "/slack/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "test-task-partial-1").First(&updatedTask)
+
+	// U11111 (clicked) should be replaced with U33333 (only candidate)
+	// U22222 (away) cannot be replaced (no more candidates), stays as is
+	reviewerIDs := strings.Split(updatedTask.Reviewers, ",")
+	assert.Equal(t, 2, len(reviewerIDs), "should still have 2 reviewers")
+	assert.Equal(t, "U33333", strings.TrimSpace(reviewerIDs[0]),
+		"U11111 should be replaced with U33333")
+	assert.Equal(t, "U22222", strings.TrimSpace(reviewerIDs[1]),
+		"U22222 stays because no more candidates available")
+}

--- a/handlers/slack_reviewer_test.go
+++ b/handlers/slack_reviewer_test.go
@@ -495,3 +495,113 @@ func TestHandleSlackAction_ChangeReviewer_SingleReviewer_English(t *testing.T) {
 	db.Where("id = ?", "test-task-en-2").First(&updatedTask)
 	assert.Equal(t, "U11111", updatedTask.Reviewer)
 }
+
+// Test that away reviewers are also replaced when "change reviewer" button is clicked
+func TestHandleSlackAction_ChangeReviewer_AlsoReplacesAwayReviewers(t *testing.T) {
+	services.IsTestMode = true
+	defer func() { services.IsTestMode = false }()
+
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/slack/action", HandleSlackAction(db))
+
+	// Create config with 5 reviewers
+	config := models.ChannelConfig{
+		ID:               "config-away-1",
+		SlackChannelID:   "C12345",
+		LabelName:        "needs-review",
+		DefaultMentionID: "U00000",
+		ReviewerList:     "U11111,U22222,U33333,U44444,U55555",
+		IsActive:         true,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+	db.Create(&config)
+
+	// Create task with 2 reviewers assigned: U11111 and U22222
+	task := models.ReviewTask{
+		ID:           "test-task-away-1",
+		PRURL:        "https://github.com/test/repo/pull/20",
+		Repo:         "test/repo",
+		PRNumber:     20,
+		Title:        "Test PR Away",
+		SlackTS:      "5555.1111",
+		SlackChannel: "C12345",
+		Status:       "in_review",
+		Reviewer:     "U11111",
+		Reviewers:    "U11111,U22222",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	// Set U22222 as away (on vacation)
+	away := models.ReviewerAvailability{
+		ID:          "away-1",
+		SlackUserID: "U22222",
+		AwayUntil:   nil, // indefinitely away
+		Reason:      "vacation",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	db.Create(&away)
+
+	// Click "change reviewer" for U11111 (replacingReviewerID = U11111)
+	payload := SlackActionPayload{
+		Type: "block_actions",
+		User: struct {
+			ID string `json:"id"`
+		}{ID: "U99999"},
+		Actions: []struct {
+			ActionID       string `json:"action_id"`
+			Value          string `json:"value,omitempty"`
+			SelectedOption struct {
+				Value string `json:"value"`
+				Text  struct {
+					Text string `json:"text"`
+				} `json:"text"`
+			} `json:"selected_option,omitempty"`
+		}{
+			{
+				ActionID: "change_reviewer",
+				Value:    "test-task-away-1:U11111", // replacing U11111
+			},
+		},
+		Container: struct {
+			ChannelID string `json:"channel_id"`
+		}{ChannelID: "C12345"},
+		Message: struct {
+			Ts string `json:"ts"`
+		}{Ts: "5555.1111"},
+	}
+
+	payloadJSON, _ := json.Marshal(payload)
+	form := url.Values{}
+	form.Add("payload", string(payloadJSON))
+
+	req := httptest.NewRequest("POST", "/slack/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "test-task-away-1").First(&updatedTask)
+
+	// Both U11111 (clicked) and U22222 (away) should be replaced
+	reviewerIDs := strings.Split(updatedTask.Reviewers, ",")
+	assert.Equal(t, 2, len(reviewerIDs), "should still have 2 reviewers")
+
+	for _, id := range reviewerIDs {
+		trimmed := strings.TrimSpace(id)
+		assert.NotEqual(t, "U11111", trimmed, "U11111 (clicked) should be replaced")
+		assert.NotEqual(t, "U22222", trimmed, "U22222 (away) should also be replaced")
+		// Should be from the remaining candidates: U33333, U44444, U55555
+		assert.Contains(t, []string{"U33333", "U44444", "U55555"}, trimmed,
+			"new reviewers should be from available candidates")
+	}
+}


### PR DESCRIPTION
## Summary
- 「変わってほしい」ボタンクリック時に、明示的にクリックされたレビュワーだけでなく、他の休暇中レビュワーも同時に再抽選するように改善
- replacementMapの構築順序を決定的にし（sort + explicit優先）、テスト結果の安定性を確保
- 候補不足時は明示クリック分を優先的に置換し、残りは部分置換（partial replacement）として維持

## Test plan
- [x] 明示クリック + 休暇中レビュワーの両方が置換されるケース
- [x] 休暇中レビュワーがいない場合、クリック分のみ置換されるケース
- [x] 候補不足時に明示クリック優先で部分置換されるケース
- [x] 既存テスト全件パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)