### PR TITLE
set-awayコマンドに事前予約（from/on）オプションを追加

### DIFF
--- a/e2e/i18n-e2e.test.ts
+++ b/e2e/i18n-e2e.test.ts
@@ -372,15 +372,57 @@ test.describe("18. set-away", () => {
     const res = await slackCmd(request, "set-away");
     expect(res).toContain("休暇に設定するユーザー");
   });
+
+  test("18-5. set away with from and until (scheduled)", async ({
+    request,
+  }) => {
+    const res = await slackCmd(
+      request,
+      "set-away <@UAWAY4> from 2099-06-01 until 2099-06-15 reason 予定休暇"
+    );
+    expect(res).toContain("休暇に設定しました");
+    expect(res).toContain("2099-06-01 ~ 2099-06-15");
+    expect(res).toContain("予定休暇");
+  });
+
+  test("18-6. set away with on (single day)", async ({ request }) => {
+    const res = await slackCmd(
+      request,
+      "set-away <@UAWAY5> on 2099-07-01 reason 有給休暇"
+    );
+    expect(res).toContain("休暇に設定しました");
+    expect(res).toContain("2099-07-01");
+    expect(res).toContain("有給休暇");
+  });
+
+  test("18-7. from after until is rejected", async ({ request }) => {
+    const res = await slackCmd(
+      request,
+      "set-away <@UAWAY6> from 2099-12-31 until 2099-01-01"
+    );
+    expect(res).toContain("開始日（from）は終了日（until）より前に");
+  });
+
+  test("18-8. past from date is rejected", async ({ request }) => {
+    const res = await slackCmd(
+      request,
+      "set-away <@UAWAY7> from 2020-01-01 until 2099-12-31"
+    );
+    expect(res).toContain("過去の日付");
+  });
 });
 
 // ── 19. show-availability ────────────────────────────────────────
 
 test.describe("19. show-availability", () => {
-  test("19-1. show users on leave", async ({ request }) => {
+  test("19-1. show users on leave with status labels", async ({ request }) => {
     const res = await slackCmd(request, "show-availability");
-    expect(res).toContain("休暇中のユーザー");
+    expect(res).toContain("休暇中・予約中のユーザー");
     expect(res).toContain("<@UAWAY1>");
+    expect(res).toContain("休暇中");
+    // UAWAY4 has a future from date, so it should show as scheduled
+    expect(res).toContain("予約中");
+    expect(res).toContain("<@UAWAY4>");
   });
 });
 
@@ -495,7 +537,7 @@ test.describe("22. set-language & i18n switching", () => {
     await slackCmd(request, "set-mention <@UI18N>", CH);
     await slackCmd(request, "set-language en", CH);
     const res = await slackCmd(request, "show-availability", CH);
-    expect(res).toContain("Currently on Leave");
+    expect(res).toContain("on Leave / Scheduled");
   });
 
   test("22-12. unset-away in English", async ({ request }) => {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -440,3 +440,110 @@ func TestE2E_MultipleReReviews_OutsideBusinessHours_AllSendLater(t *testing.T) {
 	db.Where("id = ?", "e2e-multi-rereview").First(&deferredTask)
 	assert.False(t, deferredTask.PendingReReviewNotify)
 }
+
+// Test: Immediate away user is excluded from reviewer assignment, but scheduled (future) away is still eligible
+func TestE2E_ScheduledAway_NotExcludedFromReviewerAssignment(t *testing.T) {
+	originalURL := os.Getenv("SLACK_API_BASE_URL")
+	os.Setenv("SLACK_API_BASE_URL", slackhogBaseURL+"/api")
+	defer os.Setenv("SLACK_API_BASE_URL", originalURL)
+
+	services.IsTestMode = true
+	db, ts := setupE2EApp(t)
+	defer ts.Close()
+	clearSlackhogMessages(t)
+
+	// Setup channel config with 3 reviewers: U_R1, U_R2, U_R3
+	config := models.ChannelConfig{
+		ID:                 "e2e-away-config",
+		SlackChannelID:     "C_E2E_BH",
+		LabelName:          "needs-review",
+		DefaultMentionID:   "U_E2E_DEFAULT",
+		RepositoryList:    "e2e-owner/e2e-repo",
+		ReviewerList:      "U_R1,U_R2,U_R3",
+		RequiredApprovals: 2,
+		IsActive:           true,
+		BusinessHoursStart: "00:00",
+		BusinessHoursEnd:   "23:59",
+		Timezone:           "Asia/Tokyo",
+	}
+	db.Create(&config)
+
+	now := time.Now()
+	future := now.Add(7 * 24 * time.Hour) // 1 week from now
+
+	// U_R1: immediately away (no AwayFrom, indefinite)
+	db.Create(&models.ReviewerAvailability{
+		ID:          "e2e-away-immediate",
+		SlackUserID: "U_R1",
+		AwayFrom:    nil,
+		AwayUntil:   nil,
+		Reason:      "育児休業",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+
+	// U_R2: scheduled away (future AwayFrom)
+	db.Create(&models.ReviewerAvailability{
+		ID:          "e2e-away-scheduled",
+		SlackUserID: "U_R2",
+		AwayFrom:    &future,
+		AwayUntil:   nil,
+		Reason:      "来週から休暇",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+
+	// Send labeled webhook
+	payload := `{
+		"action": "labeled",
+		"label": {"name": "needs-review"},
+		"pull_request": {
+			"number": 100,
+			"html_url": "https://github.com/e2e-owner/e2e-repo/pull/100",
+			"title": "E2E Scheduled Away Test PR",
+			"user": {"login": "e2e-author"},
+			"labels": [{"name": "needs-review"}]
+		},
+		"repository": {"full_name": "e2e-owner/e2e-repo", "owner": {"login": "e2e-owner"}, "name": "e2e-repo"},
+		"sender": {"login": "e2e-author"}
+	}`
+	resp := sendWebhook(t, ts.URL, payload)
+	resp.Body.Close()
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify: slackhog received a message in C_E2E_BH
+	msgs := getSlackhogMessages(t, "C_E2E_BH")
+	require.NotEmpty(t, msgs, "Should have at least one message in slackhog")
+
+	// Find the PR notification message
+	var prMsg *slackhogMessage
+	for i, m := range msgs {
+		if strings.Contains(m.Text, "pull/100") || strings.Contains(m.Text, "E2E Scheduled Away Test PR") {
+			prMsg = &msgs[i]
+			break
+		}
+	}
+
+	// Get thread replies for reviewer assignment
+	if prMsg != nil {
+		replies := getSlackhogReplies(t, prMsg.ID)
+		allText := prMsg.Text
+		for _, r := range replies {
+			allText += " " + r.Text
+		}
+
+		// U_R1 (immediate away) should NOT be assigned
+		assert.NotContains(t, allText, "<@U_R1>", "Immediately away user should not be assigned as reviewer")
+
+		// U_R2 (scheduled future away) should still be eligible
+		// U_R3 is always eligible
+		// With 2 reviewers needed and U_R1 excluded, U_R2 and U_R3 should both be assigned
+		assert.Contains(t, allText, "<@U_R2>", "Scheduled (future) away user should still be eligible for review")
+		assert.Contains(t, allText, "<@U_R3>", "Available user should be assigned as reviewer")
+	}
+
+	// Verify the review task was created
+	var task models.ReviewTask
+	err := db.Where("pr_number = ? AND slack_channel = ?", 100, "C_E2E_BH").First(&task).Error
+	assert.NoError(t, err, "Review task should be created")
+}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -525,22 +525,22 @@ func TestE2E_ScheduledAway_NotExcludedFromReviewerAssignment(t *testing.T) {
 	}
 
 	// Get thread replies for reviewer assignment
-	if prMsg != nil {
-		replies := getSlackhogReplies(t, prMsg.ID)
-		allText := prMsg.Text
-		for _, r := range replies {
-			allText += " " + r.Text
-		}
+	require.NotNil(t, prMsg, "PR notification message should be found in slackhog")
 
-		// U_R1 (immediate away) should NOT be assigned
-		assert.NotContains(t, allText, "<@U_R1>", "Immediately away user should not be assigned as reviewer")
-
-		// U_R2 (scheduled future away) should still be eligible
-		// U_R3 is always eligible
-		// With 2 reviewers needed and U_R1 excluded, U_R2 and U_R3 should both be assigned
-		assert.Contains(t, allText, "<@U_R2>", "Scheduled (future) away user should still be eligible for review")
-		assert.Contains(t, allText, "<@U_R3>", "Available user should be assigned as reviewer")
+	replies := getSlackhogReplies(t, prMsg.ID)
+	allText := prMsg.Text
+	for _, r := range replies {
+		allText += " " + r.Text
 	}
+
+	// U_R1 (immediate away) should NOT be assigned
+	assert.NotContains(t, allText, "<@U_R1>", "Immediately away user should not be assigned as reviewer")
+
+	// U_R2 (scheduled future away) should still be eligible
+	// U_R3 is always eligible
+	// With 2 reviewers needed and U_R1 excluded, U_R2 and U_R3 should both be assigned
+	assert.Contains(t, allText, "<@U_R2>", "Scheduled (future) away user should still be eligible for review")
+	assert.Contains(t, allText, "<@U_R3>", "Available user should be assigned as reviewer")
 
 	// Verify the review task was created
 	var task models.ReviewTask

--- a/handlers/command.go
+++ b/handlers/command.go
@@ -1134,59 +1134,83 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 	}
 	loc, err := time.LoadLocation(timezone)
 	if err != nil {
+		log.Printf("invalid timezone %q, falling back to UTC: %v", timezone, err)
 		loc = time.UTC
 	}
+
+	nowLocal := time.Now().In(loc)
+	todayStart := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 0, 0, 0, loc)
+	hasOn := false
 
 	// Parse parameters: "from", "until", "on", and "reason" keywords
 	for i := 1; i < len(parts); i++ {
 		switch parts[i] {
 		case "from":
-			if i+1 < len(parts) {
-				i++
-				parsed, err := time.Parse("2006-01-02", parts[i])
-				if err != nil {
-					c.String(200, t("cmd.set_away.invalid_date"))
-					return
-				}
-				startOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 0, 0, 0, 0, loc)
-				if startOfDay.Before(time.Date(time.Now().In(loc).Year(), time.Now().In(loc).Month(), time.Now().In(loc).Day(), 0, 0, 0, 0, loc)) {
-					c.String(200, t("cmd.set_away.past_date"))
-					return
-				}
-				awayFrom = &startOfDay
+			if hasOn {
+				c.String(200, t("cmd.set_away.conflicting_keywords"))
+				return
 			}
+			if i+1 >= len(parts) {
+				c.String(200, t("cmd.set_away.missing_date"))
+				return
+			}
+			i++
+			parsed, err := time.Parse("2006-01-02", parts[i])
+			if err != nil {
+				c.String(200, t("cmd.set_away.invalid_date"))
+				return
+			}
+			startOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 0, 0, 0, 0, loc)
+			if startOfDay.Before(todayStart) {
+				c.String(200, t("cmd.set_away.past_date"))
+				return
+			}
+			awayFrom = &startOfDay
 		case "until":
-			if i+1 < len(parts) {
-				i++
-				parsed, err := time.Parse("2006-01-02", parts[i])
-				if err != nil {
-					c.String(200, t("cmd.set_away.invalid_date"))
-					return
-				}
-				endOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, 0, loc)
-				if endOfDay.Before(time.Now().In(loc)) {
-					c.String(200, t("cmd.set_away.past_date"))
-					return
-				}
-				awayUntil = &endOfDay
+			if hasOn {
+				c.String(200, t("cmd.set_away.conflicting_keywords"))
+				return
 			}
+			if i+1 >= len(parts) {
+				c.String(200, t("cmd.set_away.missing_date"))
+				return
+			}
+			i++
+			parsed, err := time.Parse("2006-01-02", parts[i])
+			if err != nil {
+				c.String(200, t("cmd.set_away.invalid_date"))
+				return
+			}
+			endOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, 0, loc)
+			if endOfDay.Before(nowLocal) {
+				c.String(200, t("cmd.set_away.past_date"))
+				return
+			}
+			awayUntil = &endOfDay
 		case "on":
-			if i+1 < len(parts) {
-				i++
-				parsed, err := time.Parse("2006-01-02", parts[i])
-				if err != nil {
-					c.String(200, t("cmd.set_away.invalid_date"))
-					return
-				}
-				startOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 0, 0, 0, 0, loc)
-				endOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, 0, loc)
-				if endOfDay.Before(time.Now().In(loc)) {
-					c.String(200, t("cmd.set_away.past_date"))
-					return
-				}
-				awayFrom = &startOfDay
-				awayUntil = &endOfDay
+			if awayFrom != nil || awayUntil != nil {
+				c.String(200, t("cmd.set_away.conflicting_keywords"))
+				return
 			}
+			if i+1 >= len(parts) {
+				c.String(200, t("cmd.set_away.missing_date"))
+				return
+			}
+			i++
+			parsed, err := time.Parse("2006-01-02", parts[i])
+			if err != nil {
+				c.String(200, t("cmd.set_away.invalid_date"))
+				return
+			}
+			startOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 0, 0, 0, 0, loc)
+			endOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, 0, loc)
+			if endOfDay.Before(nowLocal) {
+				c.String(200, t("cmd.set_away.past_date"))
+				return
+			}
+			awayFrom = &startOfDay
+			awayUntil = &endOfDay
+			hasOn = true
 		case "reason":
 			if i+1 < len(parts) {
 				reason = strings.Join(parts[i+1:], " ")
@@ -1210,7 +1234,7 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 		existing.Reason = reason
 		existing.UpdatedAt = time.Now()
 		if err := db.Save(&existing).Error; err != nil {
-			log.Printf("failed to update reviewer availability: %v", err)
+			log.Printf("failed to update reviewer availability: slackUserID=%s channelID=%s err=%v", slackUserID, channelID, err)
 			c.String(200, t("cmd.set_away.update_error"))
 			return
 		}
@@ -1225,7 +1249,7 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 			UpdatedAt:   time.Now(),
 		}
 		if err := db.Create(&record).Error; err != nil {
-			log.Printf("failed to create reviewer availability: %v", err)
+			log.Printf("failed to create reviewer availability: slackUserID=%s channelID=%s err=%v", slackUserID, channelID, err)
 			c.String(200, t("cmd.set_away.create_error"))
 			return
 		}
@@ -1237,20 +1261,7 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 		openParen, closeParen = " (", ")"
 	}
 	response := t("cmd.set_away.success", slackUserID)
-
-	// Build date range description
-	switch {
-	case awayFrom != nil && awayUntil != nil && awayFrom.Format("2006-01-02") == awayUntil.Format("2006-01-02"):
-		response += openParen + t("common.on_date", awayFrom.Format("2006-01-02"))
-	case awayFrom != nil && awayUntil != nil:
-		response += openParen + t("common.from_until", awayFrom.Format("2006-01-02"), awayUntil.Format("2006-01-02"))
-	case awayFrom != nil:
-		response += openParen + t("common.from_until", awayFrom.Format("2006-01-02"), t("common.indefinite"))
-	case awayUntil != nil:
-		response += openParen + t("common.until", awayUntil.Format("2006-01-02"))
-	default:
-		response += openParen + t("common.indefinite")
-	}
+	response += openParen + formatDateRange(awayFrom, awayUntil, t)
 
 	if reason != "" {
 		response += t("common.reason", reason) + closeParen
@@ -1284,13 +1295,32 @@ func unsetAway(c *gin.Context, db *gorm.DB, params, lang string) {
 	c.String(200, t("cmd.unset_away.success", slackUserID))
 }
 
+// formatDateRange returns a human-readable date range string for away periods.
+func formatDateRange(awayFrom, awayUntil *time.Time, t func(string, ...interface{}) string) string {
+	isSameDay := awayFrom != nil && awayUntil != nil &&
+		awayFrom.Year() == awayUntil.Year() && awayFrom.YearDay() == awayUntil.YearDay()
+
+	switch {
+	case isSameDay:
+		return t("common.on_date", awayFrom.Format("2006-01-02"))
+	case awayFrom != nil && awayUntil != nil:
+		return t("common.from_until", awayFrom.Format("2006-01-02"), awayUntil.Format("2006-01-02"))
+	case awayFrom != nil:
+		return t("common.from_until", awayFrom.Format("2006-01-02"), t("common.indefinite"))
+	case awayUntil != nil:
+		return t("common.until", awayUntil.Format("2006-01-02"))
+	default:
+		return t("common.indefinite")
+	}
+}
+
 // showAvailability displays a list of users currently on leave
 func showAvailability(c *gin.Context, db *gorm.DB, lang string) {
 	t := i18n.L(lang)
 	var records []models.ReviewerAvailability
 	now := time.Now()
 
-	// Get records where AwayUntil is nil (indefinite) or in the future
+	// Get non-expired records (currently away or scheduled for the future)
 	db.Where("away_until IS NULL OR away_until > ?", now).Find(&records)
 
 	if len(records) == 0 {
@@ -1310,20 +1340,7 @@ func showAvailability(c *gin.Context, db *gorm.DB, lang string) {
 		}
 
 		line := fmt.Sprintf("• <@%s> [%s] ", r.SlackUserID, statusLabel)
-
-		// Build date range
-		switch {
-		case r.AwayFrom != nil && r.AwayUntil != nil && r.AwayFrom.Format("2006-01-02") == r.AwayUntil.Format("2006-01-02"):
-			line += t("common.on_date", r.AwayFrom.Format("2006-01-02"))
-		case r.AwayFrom != nil && r.AwayUntil != nil:
-			line += t("common.from_until", r.AwayFrom.Format("2006-01-02"), r.AwayUntil.Format("2006-01-02"))
-		case r.AwayFrom != nil:
-			line += t("common.from_until", r.AwayFrom.Format("2006-01-02"), t("common.indefinite"))
-		case r.AwayUntil != nil:
-			line += t("common.until", r.AwayUntil.Format("2006-01-02"))
-		default:
-			line += t("common.indefinite")
-		}
+		line += formatDateRange(r.AwayFrom, r.AwayUntil, t)
 
 		if r.Reason != "" {
 			line += t("common.reason_paren", r.Reason)

--- a/handlers/command.go
+++ b/handlers/command.go
@@ -1120,12 +1120,41 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 		return
 	}
 
+	var awayFrom *time.Time
 	var awayUntil *time.Time
 	var reason string
 
-	// Parse parameters: "until" and "reason" keywords
+	// Get timezone from channel config
+	timezone := "Asia/Tokyo"
+	var tzConfig models.ChannelConfig
+	if err := db.Where("slack_channel_id = ? AND label_name = ?", channelID, labelName).First(&tzConfig).Error; err == nil {
+		if tzConfig.Timezone != "" {
+			timezone = tzConfig.Timezone
+		}
+	}
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+
+	// Parse parameters: "from", "until", "on", and "reason" keywords
 	for i := 1; i < len(parts); i++ {
 		switch parts[i] {
+		case "from":
+			if i+1 < len(parts) {
+				i++
+				parsed, err := time.Parse("2006-01-02", parts[i])
+				if err != nil {
+					c.String(200, t("cmd.set_away.invalid_date"))
+					return
+				}
+				startOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 0, 0, 0, 0, loc)
+				if startOfDay.Before(time.Date(time.Now().In(loc).Year(), time.Now().In(loc).Month(), time.Now().In(loc).Day(), 0, 0, 0, 0, loc)) {
+					c.String(200, t("cmd.set_away.past_date"))
+					return
+				}
+				awayFrom = &startOfDay
+			}
 		case "until":
 			if i+1 < len(parts) {
 				i++
@@ -1134,24 +1163,28 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 					c.String(200, t("cmd.set_away.invalid_date"))
 					return
 				}
-				// Set to end of the specified day (23:59:59)
-				// Get timezone from channel config
-				timezone := "Asia/Tokyo"
-				var tzConfig models.ChannelConfig
-				if err := db.Where("slack_channel_id = ? AND label_name = ?", channelID, labelName).First(&tzConfig).Error; err == nil {
-					if tzConfig.Timezone != "" {
-						timezone = tzConfig.Timezone
-					}
-				}
-				loc, err := time.LoadLocation(timezone)
-				if err != nil {
-					loc = time.UTC
-				}
 				endOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, 0, loc)
 				if endOfDay.Before(time.Now().In(loc)) {
 					c.String(200, t("cmd.set_away.past_date"))
 					return
 				}
+				awayUntil = &endOfDay
+			}
+		case "on":
+			if i+1 < len(parts) {
+				i++
+				parsed, err := time.Parse("2006-01-02", parts[i])
+				if err != nil {
+					c.String(200, t("cmd.set_away.invalid_date"))
+					return
+				}
+				startOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 0, 0, 0, 0, loc)
+				endOfDay := time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, 0, loc)
+				if endOfDay.Before(time.Now().In(loc)) {
+					c.String(200, t("cmd.set_away.past_date"))
+					return
+				}
+				awayFrom = &startOfDay
 				awayUntil = &endOfDay
 			}
 		case "reason":
@@ -1162,10 +1195,17 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 		}
 	}
 
+	// Validate from < until when both are specified
+	if awayFrom != nil && awayUntil != nil && !awayFrom.Before(*awayUntil) {
+		c.String(200, t("cmd.set_away.from_after_until"))
+		return
+	}
+
 	// Update if existing record exists, otherwise create new (upsert)
 	var existing models.ReviewerAvailability
 	result := db.Where("slack_user_id = ?", slackUserID).First(&existing)
 	if result.Error == nil {
+		existing.AwayFrom = awayFrom
 		existing.AwayUntil = awayUntil
 		existing.Reason = reason
 		existing.UpdatedAt = time.Now()
@@ -1178,6 +1218,7 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 		record := models.ReviewerAvailability{
 			ID:          uuid.NewString(),
 			SlackUserID: slackUserID,
+			AwayFrom:    awayFrom,
 			AwayUntil:   awayUntil,
 			Reason:      reason,
 			CreatedAt:   time.Now(),
@@ -1196,11 +1237,21 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 		openParen, closeParen = " (", ")"
 	}
 	response := t("cmd.set_away.success", slackUserID)
-	if awayUntil != nil {
+
+	// Build date range description
+	switch {
+	case awayFrom != nil && awayUntil != nil && awayFrom.Format("2006-01-02") == awayUntil.Format("2006-01-02"):
+		response += openParen + t("common.on_date", awayFrom.Format("2006-01-02"))
+	case awayFrom != nil && awayUntil != nil:
+		response += openParen + t("common.from_until", awayFrom.Format("2006-01-02"), awayUntil.Format("2006-01-02"))
+	case awayFrom != nil:
+		response += openParen + t("common.from_until", awayFrom.Format("2006-01-02"), t("common.indefinite"))
+	case awayUntil != nil:
 		response += openParen + t("common.until", awayUntil.Format("2006-01-02"))
-	} else {
+	default:
 		response += openParen + t("common.indefinite")
 	}
+
 	if reason != "" {
 		response += t("common.reason", reason) + closeParen
 	} else {
@@ -1249,12 +1300,31 @@ func showAvailability(c *gin.Context, db *gorm.DB, lang string) {
 
 	response := t("cmd.show_availability.header")
 	for _, r := range records {
-		line := fmt.Sprintf("• <@%s> - ", r.SlackUserID)
-		if r.AwayUntil != nil {
-			line += t("common.until", r.AwayUntil.Format("2006-01-02"))
+		// Determine status: scheduled (AwayFrom is in the future) or currently away
+		isScheduled := r.AwayFrom != nil && r.AwayFrom.After(now)
+		var statusLabel string
+		if isScheduled {
+			statusLabel = t("cmd.show_availability.status_scheduled")
 		} else {
+			statusLabel = t("cmd.show_availability.status_away")
+		}
+
+		line := fmt.Sprintf("• <@%s> [%s] ", r.SlackUserID, statusLabel)
+
+		// Build date range
+		switch {
+		case r.AwayFrom != nil && r.AwayUntil != nil && r.AwayFrom.Format("2006-01-02") == r.AwayUntil.Format("2006-01-02"):
+			line += t("common.on_date", r.AwayFrom.Format("2006-01-02"))
+		case r.AwayFrom != nil && r.AwayUntil != nil:
+			line += t("common.from_until", r.AwayFrom.Format("2006-01-02"), r.AwayUntil.Format("2006-01-02"))
+		case r.AwayFrom != nil:
+			line += t("common.from_until", r.AwayFrom.Format("2006-01-02"), t("common.indefinite"))
+		case r.AwayUntil != nil:
+			line += t("common.until", r.AwayUntil.Format("2006-01-02"))
+		default:
 			line += t("common.indefinite")
 		}
+
 		if r.Reason != "" {
 			line += t("common.reason_paren", r.Reason)
 		}

--- a/handlers/command_db_test.go
+++ b/handlers/command_db_test.go
@@ -296,11 +296,39 @@ func TestSetAway_Integration(t *testing.T) {
 			expectedBody:   "育児休業",
 		},
 		{
+			name:           "Leave setting with from and until",
+			text:           "set-away <@U22222> from 2099-11-01 until 2099-12-31 reason 長期休暇",
+			channelID:      "C12345",
+			expectedStatus: 200,
+			expectedBody:   "2099-11-01 ~ 2099-12-31",
+		},
+		{
+			name:           "Leave setting with on (single day)",
+			text:           "set-away <@U33333> on 2099-06-15 reason 有給休暇",
+			channelID:      "C12345",
+			expectedStatus: 200,
+			expectedBody:   "2099-06-15",
+		},
+		{
 			name:           "Past date is rejected",
 			text:           "set-away <@U99999> until 2020-01-01",
 			channelID:      "C12345",
 			expectedStatus: 200,
 			expectedBody:   "過去の日付は指定できません",
+		},
+		{
+			name:           "Past from date is rejected",
+			text:           "set-away <@U99999> from 2020-01-01 until 2099-12-31",
+			channelID:      "C12345",
+			expectedStatus: 200,
+			expectedBody:   "過去の日付は指定できません",
+		},
+		{
+			name:           "from after until is rejected",
+			text:           "set-away <@U99999> from 2099-12-31 until 2099-01-01",
+			channelID:      "C12345",
+			expectedStatus: 200,
+			expectedBody:   "開始日（from）は終了日（until）より前に指定してください",
 		},
 		{
 			name:           "No user specified",
@@ -386,7 +414,7 @@ func TestShowAvailability_Integration(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	assert.Equal(t, 200, w.Code)
-	assert.Contains(t, w.Body.String(), "休暇中のユーザーはいません")
+	assert.Contains(t, w.Body.String(), "休暇中・予約中のユーザーはいません")
 
 	// Add users on leave
 	req2 := setupHTTPRequest(t, "set-away <@USHOW1> reason 休暇", "C12345")
@@ -399,15 +427,23 @@ func TestShowAvailability_Integration(t *testing.T) {
 	router.ServeHTTP(w3, req3)
 	assert.Equal(t, 200, w3.Code)
 
+	// Add a scheduled (future) leave
+	req3b := setupHTTPRequest(t, "set-away <@USHOW3> from 2099-06-01 until 2099-06-15 reason 予定休暇", "C12345")
+	w3b := httptest.NewRecorder()
+	router.ServeHTTP(w3b, req3b)
+	assert.Equal(t, 200, w3b.Code)
+
 	// Verify the leave list
 	req4 := setupHTTPRequest(t, "show-availability", "C12345")
 	w4 := httptest.NewRecorder()
 	router.ServeHTTP(w4, req4)
 	assert.Equal(t, 200, w4.Code)
 	body := w4.Body.String()
-	assert.Contains(t, body, "現在休暇中のユーザー")
+	assert.Contains(t, body, "休暇中・予約中のユーザー")
 	assert.Contains(t, body, "USHOW1")
 	assert.Contains(t, body, "USHOW2")
-	assert.Contains(t, body, "休暇")
-	assert.Contains(t, body, "育児休業")
+	assert.Contains(t, body, "休暇中")   // status label for currently away
+	assert.Contains(t, body, "予約中")   // status label for scheduled
+	assert.Contains(t, body, "USHOW3")
+	assert.Contains(t, body, "予定休暇")
 }

--- a/handlers/command_db_test.go
+++ b/handlers/command_db_test.go
@@ -331,6 +331,20 @@ func TestSetAway_Integration(t *testing.T) {
 			expectedBody:   "開始日（from）は終了日（until）より前に指定してください",
 		},
 		{
+			name:           "on combined with from is rejected",
+			text:           "set-away <@U99999> on 2099-06-01 from 2099-05-01",
+			channelID:      "C12345",
+			expectedStatus: 200,
+			expectedBody:   "同時に使えません",
+		},
+		{
+			name:           "from without date value is rejected",
+			text:           "set-away <@U99999> from",
+			channelID:      "C12345",
+			expectedStatus: 200,
+			expectedBody:   "キーワードの後に日付を指定してください",
+		},
+		{
 			name:           "No user specified",
 			text:           "set-away",
 			channelID:      "C12345",

--- a/i18n/messages_en.go
+++ b/i18n/messages_en.go
@@ -69,8 +69,8 @@ Specify multiple labels separated by commas to notify only when all labels are p
 • /slack-review-notify remove-user-mapping <github-username> - Remove user mapping
 
 *Leave Management:*
-• /slack-review-notify set-away @user [from YYYY-MM-DD] [until YYYY-MM-DD] [reason description] - Set user as away
-• /slack-review-notify set-away @user on YYYY-MM-DD [reason description] - Set away for a single day
+• /slack-review-notify set-away @user from [YYYY-MM-DD] until [YYYY-MM-DD] reason [description] - Set user as away
+• /slack-review-notify set-away @user on [YYYY-MM-DD] reason [description] - Set away for a single day
 • /slack-review-notify unset-away @user - Remove user's away status
 • /slack-review-notify show-availability - Show users on leave or scheduled
 

--- a/i18n/messages_en.go
+++ b/i18n/messages_en.go
@@ -192,7 +192,9 @@ Omitting [label-name] uses the default label "needs-review"`,
 
 	// ==================== Command: set-away ====================
 	"cmd.set_away.usage":        "Please specify a user to set as away.\nExamples:\n  set-away @user\n  set-away @user until 2025-06-01\n  set-away @user from 2025-05-28 until 2025-06-01\n  set-away @user on 2025-06-01\n  set-away @user on 2025-06-01 reason Day off",
-	"cmd.set_away.from_after_until": "The start date (from) must be before the end date (until).",
+	"cmd.set_away.from_after_until":  "The start date (from) must be before the end date (until).",
+	"cmd.set_away.missing_date":     "Please specify a date after the keyword. Example: from 2025-06-01",
+	"cmd.set_away.conflicting_keywords": "Cannot combine `on` with `from`/`until`. Use either `on YYYY-MM-DD` or `from YYYY-MM-DD until YYYY-MM-DD`.",
 	"cmd.set_away.no_user":      "Please specify a user to set as away.",
 	"cmd.set_away.invalid_date": "Invalid date format. Please use YYYY-MM-DD format (e.g., 2025-06-01).",
 	"cmd.set_away.past_date":    "Cannot specify a past date. Please specify today or a future date.",

--- a/i18n/messages_en.go
+++ b/i18n/messages_en.go
@@ -69,9 +69,10 @@ Specify multiple labels separated by commas to notify only when all labels are p
 • /slack-review-notify remove-user-mapping <github-username> - Remove user mapping
 
 *Leave Management:*
-• /slack-review-notify set-away @user [until YYYY-MM-DD] [reason description] - Set user as away
+• /slack-review-notify set-away @user [from YYYY-MM-DD] [until YYYY-MM-DD] [reason description] - Set user as away
+• /slack-review-notify set-away @user on YYYY-MM-DD [reason description] - Set away for a single day
 • /slack-review-notify unset-away @user - Remove user's away status
-• /slack-review-notify show-availability - Show users currently on leave
+• /slack-review-notify show-availability - Show users on leave or scheduled
 
 Omitting [label-name] uses the default label "needs-review"`,
 
@@ -190,7 +191,8 @@ Omitting [label-name] uses the default label "needs-review"`,
 	"cmd.remove_user_mapping.success":   "Deleted mapping for GitHub user `%s`.",
 
 	// ==================== Command: set-away ====================
-	"cmd.set_away.usage":        "Please specify a user to set as away. Example: /slack-review-notify set-away @user [until YYYY-MM-DD] [reason description]",
+	"cmd.set_away.usage":        "Please specify a user to set as away.\nExamples:\n  set-away @user\n  set-away @user until 2025-06-01\n  set-away @user from 2025-05-28 until 2025-06-01\n  set-away @user on 2025-06-01\n  set-away @user on 2025-06-01 reason Day off",
+	"cmd.set_away.from_after_until": "The start date (from) must be before the end date (until).",
 	"cmd.set_away.no_user":      "Please specify a user to set as away.",
 	"cmd.set_away.invalid_date": "Invalid date format. Please use YYYY-MM-DD format (e.g., 2025-06-01).",
 	"cmd.set_away.past_date":    "Cannot specify a past date. Please specify today or a future date.",
@@ -204,8 +206,10 @@ Omitting [label-name] uses the default label "needs-review"`,
 	"cmd.unset_away.success": "Removed away status for <@%s>",
 
 	// ==================== Command: show-availability ====================
-	"cmd.show_availability.empty":  "No users are currently on leave.",
-	"cmd.show_availability.header": "*Users Currently on Leave*\n",
+	"cmd.show_availability.empty":           "No users are currently on leave or scheduled.",
+	"cmd.show_availability.header":          "*Users on Leave / Scheduled*\n",
+	"cmd.show_availability.status_away":     "Away",
+	"cmd.show_availability.status_scheduled": "Scheduled",
 
 	// ==================== Common ====================
 	"common.active":             "Active",
@@ -214,6 +218,8 @@ Omitting [label-name] uses the default label "needs-review"`,
 	"common.invalid_user_id":    "Please specify a valid user ID.",
 	"common.select_placeholder": "Select an option",
 	"common.until":              "until %s",
+	"common.from_until":         "%s ~ %s",
+	"common.on_date":            "on %s",
 	"common.indefinite":         "Indefinite",
 	"common.reason":             ", reason: %s",
 	"common.reason_paren":       " (%s)",

--- a/i18n/messages_ja.go
+++ b/i18n/messages_ja.go
@@ -192,7 +192,9 @@ var messagesJa = map[string]string{
 
 	// ==================== Command: set-away ====================
 	"cmd.set_away.usage":        "休暇に設定するユーザーを指定してください。\n例:\n  set-away @user\n  set-away @user until 2025-06-01\n  set-away @user from 2025-05-28 until 2025-06-01\n  set-away @user on 2025-06-01\n  set-away @user on 2025-06-01 reason 有給休暇",
-	"cmd.set_away.from_after_until": "開始日（from）は終了日（until）より前に指定してください。",
+	"cmd.set_away.from_after_until":  "開始日（from）は終了日（until）より前に指定してください。",
+	"cmd.set_away.missing_date":     "キーワードの後に日付を指定してください。例: from 2025-06-01",
+	"cmd.set_away.conflicting_keywords": "`on` と `from`/`until` は同時に使えません。`on YYYY-MM-DD` または `from YYYY-MM-DD until YYYY-MM-DD` のどちらかを使用してください。",
 	"cmd.set_away.no_user":      "休暇に設定するユーザーを指定してください。",
 	"cmd.set_away.invalid_date": "日付形式が無効です。YYYY-MM-DD形式で指定してください（例: 2025-06-01）",
 	"cmd.set_away.past_date":    "過去の日付は指定できません。今日以降の日付を指定してください。",

--- a/i18n/messages_ja.go
+++ b/i18n/messages_ja.go
@@ -69,8 +69,8 @@ var messagesJa = map[string]string{
 • /slack-review-notify remove-user-mapping <github-username> - ユーザーマッピングを削除
 
 *休暇管理:*
-• /slack-review-notify set-away @user [from YYYY-MM-DD] [until YYYY-MM-DD] [reason 理由] - ユーザーを休暇に設定
-• /slack-review-notify set-away @user on YYYY-MM-DD [reason 理由] - 単一日の休暇を設定
+• /slack-review-notify set-away @user from [YYYY-MM-DD] until [YYYY-MM-DD] reason [理由] - ユーザーを休暇に設定
+• /slack-review-notify set-away @user on [YYYY-MM-DD] reason [理由] - 単一日の休暇を設定
 • /slack-review-notify unset-away @user - ユーザーの休暇を解除
 • /slack-review-notify show-availability - 休暇中・予約中のユーザー一覧を表示
 

--- a/i18n/messages_ja.go
+++ b/i18n/messages_ja.go
@@ -69,9 +69,10 @@ var messagesJa = map[string]string{
 • /slack-review-notify remove-user-mapping <github-username> - ユーザーマッピングを削除
 
 *休暇管理:*
-• /slack-review-notify set-away @user [until YYYY-MM-DD] [reason 理由] - ユーザーを休暇に設定
+• /slack-review-notify set-away @user [from YYYY-MM-DD] [until YYYY-MM-DD] [reason 理由] - ユーザーを休暇に設定
+• /slack-review-notify set-away @user on YYYY-MM-DD [reason 理由] - 単一日の休暇を設定
 • /slack-review-notify unset-away @user - ユーザーの休暇を解除
-• /slack-review-notify show-availability - 休暇中のユーザー一覧を表示
+• /slack-review-notify show-availability - 休暇中・予約中のユーザー一覧を表示
 
 [ラベル名]を省略すると「needs-review」というデフォルトのラベルを使用します`,
 
@@ -190,7 +191,8 @@ var messagesJa = map[string]string{
 	"cmd.remove_user_mapping.success":   "GitHubユーザー `%s` のマッピングを削除しました。",
 
 	// ==================== Command: set-away ====================
-	"cmd.set_away.usage":        "休暇に設定するユーザーを指定してください。例: /slack-review-notify set-away @user [until YYYY-MM-DD] [reason 理由]",
+	"cmd.set_away.usage":        "休暇に設定するユーザーを指定してください。\n例:\n  set-away @user\n  set-away @user until 2025-06-01\n  set-away @user from 2025-05-28 until 2025-06-01\n  set-away @user on 2025-06-01\n  set-away @user on 2025-06-01 reason 有給休暇",
+	"cmd.set_away.from_after_until": "開始日（from）は終了日（until）より前に指定してください。",
 	"cmd.set_away.no_user":      "休暇に設定するユーザーを指定してください。",
 	"cmd.set_away.invalid_date": "日付形式が無効です。YYYY-MM-DD形式で指定してください（例: 2025-06-01）",
 	"cmd.set_away.past_date":    "過去の日付は指定できません。今日以降の日付を指定してください。",
@@ -204,8 +206,10 @@ var messagesJa = map[string]string{
 	"cmd.unset_away.success": "<@%s> の休暇を解除しました",
 
 	// ==================== Command: show-availability ====================
-	"cmd.show_availability.empty":  "現在休暇中のユーザーはいません",
-	"cmd.show_availability.header": "*現在休暇中のユーザー*\n",
+	"cmd.show_availability.empty":           "現在休暇中・予約中のユーザーはいません",
+	"cmd.show_availability.header":          "*休暇中・予約中のユーザー*\n",
+	"cmd.show_availability.status_away":     "休暇中",
+	"cmd.show_availability.status_scheduled": "予約中",
 
 	// ==================== Common ====================
 	"common.active":             "有効",
@@ -214,6 +218,8 @@ var messagesJa = map[string]string{
 	"common.invalid_user_id":    "有効なユーザーIDを指定してください。",
 	"common.select_placeholder": "選択してください",
 	"common.until":              "%s まで",
+	"common.from_until":         "%s ~ %s",
+	"common.on_date":            "%s",
 	"common.indefinite":         "無期限",
 	"common.reason":             "、理由: %s",
 	"common.reason_paren":       "（%s）",

--- a/models/reviewer_availability.go
+++ b/models/reviewer_availability.go
@@ -9,6 +9,7 @@ import (
 type ReviewerAvailability struct {
 	ID          string         `gorm:"primaryKey"`
 	SlackUserID string         `gorm:"uniqueIndex"`
+	AwayFrom    *time.Time     // If nil, away starts immediately
 	AwayUntil   *time.Time     // If nil, the user is away indefinitely
 	Reason      string         // Reason for being away (optional)
 	CreatedAt   time.Time

--- a/services/slack.go
+++ b/services/slack.go
@@ -117,12 +117,18 @@ func buildMentionText(mentionID string) string {
 }
 
 // GetAwayUserIDs returns the user IDs of users currently on leave
+// (excludes scheduled future leaves where AwayFrom > now)
 func GetAwayUserIDs(db *gorm.DB) []string {
 	var records []models.ReviewerAvailability
 	now := time.Now()
 
-	// Retrieve records where AwayUntil is nil (indefinite) or in the future
-	db.Where("away_until IS NULL OR away_until > ?", now).Find(&records)
+	// Retrieve records that are currently active:
+	// 1. AwayFrom is nil (immediate) or in the past/present AND
+	// 2. AwayUntil is nil (indefinite) or in the future
+	db.Where(
+		"(away_from IS NULL OR away_from <= ?) AND (away_until IS NULL OR away_until > ?)",
+		now, now,
+	).Find(&records)
 
 	ids := make([]string, 0, len(records))
 	for _, r := range records {

--- a/services/slack.go
+++ b/services/slack.go
@@ -125,10 +125,13 @@ func GetAwayUserIDs(db *gorm.DB) []string {
 	// Retrieve records that are currently active:
 	// 1. AwayFrom is nil (immediate) or in the past/present AND
 	// 2. AwayUntil is nil (indefinite) or in the future
-	db.Where(
+	result := db.Where(
 		"(away_from IS NULL OR away_from <= ?) AND (away_until IS NULL OR away_until > ?)",
 		now, now,
 	).Find(&records)
+	if result.Error != nil {
+		log.Printf("failed to query away users: %v", result.Error)
+	}
 
 	ids := make([]string, 0, len(records))
 	for _, r := range records {

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -933,10 +933,34 @@ func TestGetAwayUserIDs(t *testing.T) {
 		UpdatedAt:   now,
 	})
 
+	// Scheduled future leave (AwayFrom is in the future, should not be returned)
+	db.Create(&models.ReviewerAvailability{
+		ID:          "away-4",
+		SlackUserID: "U_SCHEDULED",
+		AwayFrom:    &future,
+		AwayUntil:   nil,
+		Reason:      "来週の休暇",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+
+	// Scheduled leave that has started (AwayFrom is in the past)
+	db.Create(&models.ReviewerAvailability{
+		ID:          "away-5",
+		SlackUserID: "U_STARTED",
+		AwayFrom:    &past,
+		AwayUntil:   &future,
+		Reason:      "休暇中",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+
 	ids := GetAwayUserIDs(db)
 	assert.Contains(t, ids, "U_AWAY1")
 	assert.Contains(t, ids, "U_AWAY2")
 	assert.NotContains(t, ids, "U_EXPIRED")
+	assert.NotContains(t, ids, "U_SCHEDULED", "Scheduled future leave should not be active yet")
+	assert.Contains(t, ids, "U_STARTED", "Leave with past AwayFrom should be active")
 }
 
 func TestSelectRandomReviewers_ExcludesAwayUsers(t *testing.T) {


### PR DESCRIPTION
## 概要

- `ReviewerAvailability` モデルに `AwayFrom` フィールドを追加し、事前の休暇予約に対応する
- `from YYYY-MM-DD` オプションで開始日を指定可能にする（即時awayではなく、指定日からawayになる）
- `on YYYY-MM-DD` で単一日の休暇登録に対応する（fromとuntilを同一日にセット）
- `GetAwayUserIDs` を更新し、予約中（未来のfrom）のユーザーをレビュワー割り当てから除外しない
- `show-availability` で `[休暇中]` / `[予約中]` のステータスラベルを表示する
- ヘルプとusageメッセージに新しい構文例を追加する

### 新しいコマンド構文

```
set-away @user from 2026-04-15 until 2026-04-20 reason 休暇
set-away @user on 2026-04-15 reason 有給休暇
```

### 後方互換性

- `from` 省略時は即時away（既存の動作を維持）
- 既存テストはi18nキーの文字列更新以外、変更なしで通過する

### 過去PRフィードバックの確認

- **configのタイムゾーン使用**（PR #79）: 日付パースはすべてchannel configのタイムゾーンを使用している
- **E2Eスクリーンショットをコミットしない**（PR #92）: スクリーンショットは含まれていない

## Test plan

- [x] Unit tests: `go test ./...` — all pass
- [x] E2E tests (slackhog): `make e2e` — all pass including new `TestE2E_ScheduledAway_NotExcludedFromReviewerAssignment`
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean