### PR TITLE
営業時間外 PR にレビュワー候補がコメントしたら翌朝の指名対象に含める。

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -547,3 +547,107 @@ func TestE2E_ScheduledAway_NotExcludedFromReviewerAssignment(t *testing.T) {
 	err := db.Where("pr_number = ? AND slack_channel = ?", 100, "C_E2E_BH").First(&task).Error
 	assert.NoError(t, err, "Review task should be created")
 }
+
+// Test: Pool-member commented review on a waiting_business_hours task should be pre-assigned
+// (PR #95). Verifies that:
+//   1. task.Reviewers contains the pool member's Slack ID after the comment webhook fires
+//   2. The thread receives the "review commented" notification
+//   3. The task status is preserved as waiting_business_hours (PR #94 behavior)
+func TestE2E_PoolMemberCommentOnWaitingBusinessHours_PreAssignsReviewer(t *testing.T) {
+	originalURL := os.Getenv("SLACK_API_BASE_URL")
+	os.Setenv("SLACK_API_BASE_URL", slackhogBaseURL+"/api")
+	defer os.Setenv("SLACK_API_BASE_URL", originalURL)
+
+	services.IsTestMode = true
+	db, ts := setupE2EApp(t)
+	defer ts.Close()
+	clearSlackhogMessages(t)
+
+	const (
+		channelID    = "C_E2E_BH"
+		poolMember   = "U_E2E_POOL"
+		nonPool      = "U_E2E_NONPOOL"
+		ghPoolUser   = "e2e-pool-reviewer"
+		taskID       = "e2e-preassign-pool-task"
+		prNumber     = 200
+	)
+
+	// Channel pool contains the pool member
+	config := models.ChannelConfig{
+		ID:                "e2e-preassign-config",
+		SlackChannelID:    channelID,
+		LabelName:         "needs-review",
+		DefaultMentionID:  "U_E2E_DEFAULT",
+		ReviewerList:      poolMember + "," + nonPool,
+		IsActive:          true,
+		RequiredApprovals: 2,
+		Timezone:          "Asia/Tokyo",
+	}
+	require.NoError(t, db.Create(&config).Error)
+
+	// GitHub username -> Slack ID mapping for the pool member
+	mapping := models.UserMapping{
+		ID:             "e2e-mapping-pool",
+		GithubUsername: ghPoolUser,
+		SlackUserID:    poolMember,
+	}
+	require.NoError(t, db.Create(&mapping).Error)
+
+	// Root Slack message + waiting_business_hours review task awaiting next-morning mention
+	rootTS, parentID := postRootMessage(t, channelID, "PR notification for pull/200")
+
+	task := models.ReviewTask{
+		ID:              taskID,
+		PRURL:           "https://github.com/e2e-owner/e2e-repo/pull/200",
+		Repo:            "e2e-owner/e2e-repo",
+		PRNumber:        prNumber,
+		Title:           "E2E Pre-assign PR",
+		SlackTS:         rootTS,
+		SlackChannel:    channelID,
+		Status:          "waiting_business_hours",
+		LabelName:       "needs-review",
+		PRAuthorSlackID: "U_E2E_AUTHOR",
+		CreatedAt:       time.Now().Add(-12 * time.Hour),
+		UpdatedAt:       time.Now().Add(-12 * time.Hour),
+	}
+	require.NoError(t, db.Create(&task).Error)
+
+	// Pool member leaves a comment review on GitHub before the next-morning mention
+	payload := fmt.Sprintf(`{
+		"action": "submitted",
+		"pull_request": {"number": %d, "html_url": "https://github.com/e2e-owner/e2e-repo/pull/%d"},
+		"repository": {"full_name": "e2e-owner/e2e-repo", "owner": {"login": "e2e-owner"}, "name": "e2e-repo"},
+		"review": {"state": "commented", "user": {"login": "%s"}}
+	}`, prNumber, prNumber, ghPoolUser)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	time.Sleep(500 * time.Millisecond)
+
+	// (1) DB: task.Reviewers should now contain the pool member's Slack ID
+	var updatedTask models.ReviewTask
+	require.NoError(t, db.Where("id = ?", taskID).First(&updatedTask).Error)
+	assert.Equal(t, "waiting_business_hours", updatedTask.Status,
+		"status must be preserved (PR #94 behavior)")
+	assert.Equal(t, poolMember, updatedTask.Reviewer,
+		"single reviewer slot should be filled with the pool commenter")
+	assert.Contains(t, updatedTask.Reviewers, poolMember,
+		"reviewers list should include the pool commenter so the morning mention picks them")
+
+	// (2) Slack thread: review-commented notification should be delivered via slackhog
+	replies := getSlackhogReplies(t, parentID)
+	require.NotEmpty(t, replies, "review-commented notification should appear in thread")
+	commentNotificationFound := false
+	for _, r := range replies {
+		if strings.Contains(r.Text, "レビューコメントを残しました") || strings.Contains(r.Text, "left a review comment") {
+			commentNotificationFound = true
+			break
+		}
+	}
+	assert.True(t, commentNotificationFound,
+		"thread should contain the review-commented notification, got: %v", replies)
+}

--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -768,6 +768,12 @@ func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 				}
 			}
 
+			// waiting_business_hours のタスクにプール所属メンバーがコメントした場合、
+			// 翌朝メンション前に事前アサインしておく。
+			if latestTask.Status == "waiting_business_hours" {
+				preAssignPoolCommenter(db, &latestTask, reviewerSlackID, requiredApprovals)
+			}
+
 			// Update all tasks for the same channel and PR to completed (to prevent reminders)
 			var channelTasks []models.ReviewTask
 			db.Where("repo = ? AND pr_number = ? AND slack_channel = ? AND status IN ?",
@@ -786,4 +792,112 @@ func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 			}
 		}
 	}
+}
+
+// preAssignPoolCommenter は waiting_business_hours 状態のタスクに対し、
+// プール所属メンバーが翌朝メンション前にコメントレビューを残した場合、
+// そのユーザーを翌朝の指名対象に事前アサインする。
+//
+// 以下のいずれかに該当する場合はスキップする:
+//   - reviewerSlackID が空（マッピング未登録、またはプール外）
+//   - reviewerSlackID が PR 著者と一致する
+//   - ChannelConfig が取得できない、または ReviewerList が空
+//   - reviewerSlackID が ReviewerList に含まれない
+//   - 既に task.Reviewers に含まれている（重複排除）
+//   - 既存 reviewers 数が requiredApprovals 以上（上限打ち切り）
+//
+// Away ステータスのプール所属メンバーでもコメントしている = 本人が動いているため対象に含める。
+func preAssignPoolCommenter(db *gorm.DB, task *models.ReviewTask, reviewerSlackID string, requiredApprovals int) {
+	if reviewerSlackID == "" {
+		return
+	}
+	if reviewerSlackID == task.PRAuthorSlackID {
+		return
+	}
+
+	labelName := task.LabelName
+	if labelName == "" {
+		labelName = "needs-review"
+	}
+
+	var config models.ChannelConfig
+	if err := db.Where("slack_channel_id = ? AND label_name = ?", task.SlackChannel, labelName).First(&config).Error; err != nil {
+		log.Printf("pre-assign: channel config not found: task=%s, err=%v", task.ID, err)
+		return
+	}
+
+	if strings.TrimSpace(config.ReviewerList) == "" {
+		return
+	}
+
+	pool := make(map[string]bool)
+	for _, r := range strings.Split(config.ReviewerList, ",") {
+		if trimmed := strings.TrimSpace(r); trimmed != "" {
+			pool[trimmed] = true
+		}
+	}
+	if !pool[reviewerSlackID] {
+		return
+	}
+
+	existing := splitNonEmpty(task.Reviewers)
+	for _, id := range existing {
+		if id == reviewerSlackID {
+			return
+		}
+	}
+
+	if len(existing) >= requiredApprovals {
+		log.Printf("pre-assign skipped: already at required approvals: task=%s, existing=%d, required=%d",
+			task.ID, len(existing), requiredApprovals)
+		return
+	}
+
+	oldReviewers := task.Reviewers
+	newReviewers := append([]string{}, existing...)
+	newReviewers = append(newReviewers, reviewerSlackID)
+	newReviewersStr := strings.Join(newReviewers, ",")
+
+	updates := map[string]interface{}{
+		"reviewers":  newReviewersStr,
+		"updated_at": time.Now(),
+	}
+	if task.Reviewer == "" {
+		updates["reviewer"] = reviewerSlackID
+	}
+
+	result := db.Model(&models.ReviewTask{}).
+		Where("id = ? AND reviewers = ? AND status = ?", task.ID, oldReviewers, "waiting_business_hours").
+		Updates(updates)
+	if result.Error != nil {
+		log.Printf("pre-assign update failed: task=%s, err=%v", task.ID, result.Error)
+		return
+	}
+	if result.RowsAffected == 0 {
+		log.Printf("pre-assign CAS conflict, skipping: task=%s", task.ID)
+		return
+	}
+
+	task.Reviewers = newReviewersStr
+	if task.Reviewer == "" {
+		task.Reviewer = reviewerSlackID
+	}
+
+	log.Printf("pre-assigned reviewer to waiting_business_hours task: id=%s, reviewer=%s",
+		task.ID, reviewerSlackID)
+}
+
+// splitNonEmpty はカンマ区切り文字列を分割し、空文字列を除外したスライスを返す。
+func splitNonEmpty(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }

--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -768,11 +768,15 @@ func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 				}
 			}
 
-			// Update all tasks for the same channel and PR to completed (to prevent reminders)
+			// Update tasks for the same channel and PR to completed (to prevent reminders).
+			// waiting_business_hours is intentionally excluded: those tasks have not yet had a
+			// reviewer assigned, so a single comment/changes_requested should not cancel the
+			// next-business-day reviewer mention. (CheckInReviewTasks only reminds in_review
+			// tasks, so leaving waiting_business_hours alone does not cause reminder spam.)
 			var channelTasks []models.ReviewTask
 			db.Where("repo = ? AND pr_number = ? AND slack_channel = ? AND status IN ?",
 				repoFullName, pr.GetNumber(), channel,
-				[]string{"in_review", "pending", "snoozed", "waiting_business_hours"}).Find(&channelTasks)
+				[]string{"in_review", "pending", "snoozed"}).Find(&channelTasks)
 
 			for _, task := range channelTasks {
 				task.Status = "completed"

--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -704,7 +704,11 @@ func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 					log.Printf("failed to post review complete message: %v", err)
 				}
 
-				// All approvals met -> mark all tasks as completed
+				// All approvals met -> mark all tasks as completed.
+				// waiting_business_hours IS included here intentionally: full approval
+				// short-circuits the scheduled next-business-day reviewer mention because
+				// no further review is needed. (This is the intentional asymmetry with the
+				// commented/changes_requested branch below, which preserves waiting_business_hours.)
 				var channelTasks []models.ReviewTask
 				db.Where("repo = ? AND pr_number = ? AND slack_channel = ? AND status IN ?",
 					repoFullName, pr.GetNumber(), channel,
@@ -771,8 +775,9 @@ func handleReviewSubmittedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 			// Update tasks for the same channel and PR to completed (to prevent reminders).
 			// waiting_business_hours is intentionally excluded: those tasks have not yet had a
 			// reviewer assigned, so a single comment/changes_requested should not cancel the
-			// next-business-day reviewer mention. (CheckInReviewTasks only reminds in_review
-			// tasks, so leaving waiting_business_hours alone does not cause reminder spam.)
+			// next-business-day reviewer mention. waiting_business_hours tasks are not subject
+			// to the in-review reminder loop today (see services/tasks.go CheckInReviewTasks),
+			// so preserving them here does not produce reminder spam.
 			var channelTasks []models.ReviewTask
 			db.Where("repo = ? AND pr_number = ? AND slack_channel = ? AND status IN ?",
 				repoFullName, pr.GetNumber(), channel,

--- a/handlers/webhook_test.go
+++ b/handlers/webhook_test.go
@@ -2144,3 +2144,461 @@ func TestHandleReviewRequestedEvent_WithinBusinessHours_SendsImmediately(t *test
 	assert.False(t, updatedTask.PendingReReviewNotify, "Notification should be sent immediately without business hours config")
 	assert.True(t, gock.IsDone(), "Slack notification should have been sent")
 }
+
+// --- Tests for pre-assigning pool commenters on waiting_business_hours tasks ---
+// プール所属メンバーが翌朝メンション前にコメントレビューを残した場合、
+// そのユーザーを翌朝の指名対象に事前アサインする挙動のテスト。
+
+// setupPreAssignTest は事前アサインテスト用の DB と共通 fixture を構築する。
+// channelID / label / pool のレビュワー ID / PR 番号などを指定できる。
+func setupPreAssignTestEnv(t *testing.T) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+}
+
+func TestHandleReviewSubmittedEvent_PoolMemberCommentPreAssignsToWaitingBusinessHours(t *testing.T) {
+	db := setupTestDB(t)
+	setupPreAssignTestEnv(t)
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// プールに reviewer1 (Slack=U_R1) と reviewer2 (Slack=U_R2) を登録。
+	config := models.ChannelConfig{
+		ID:                "config-preassign-1",
+		SlackChannelID:    "C_PREASSIGN1",
+		LabelName:         "needs-review",
+		DefaultMentionID:  "UDEFAULT",
+		ReviewerList:      "U_R1,U_R2",
+		RequiredApprovals: 2,
+		IsActive:          true,
+	}
+	db.Create(&config)
+
+	db.Create(&models.UserMapping{ID: "m1", GithubUsername: "reviewer1", SlackUserID: "U_R1"})
+	db.Create(&models.UserMapping{ID: "m2", GithubUsername: "reviewer2", SlackUserID: "U_R2"})
+
+	task := models.ReviewTask{
+		ID:           "preassign-task-1",
+		PRURL:        "https://github.com/owner/repo/pull/600",
+		Repo:         "owner/repo",
+		PRNumber:     600,
+		Title:        "Waiting BH PR",
+		SlackTS:      "1234.6000",
+		SlackChannel: "C_PREASSIGN1",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+		UpdatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 600, "html_url": "https://github.com/owner/repo/pull/600"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "commented", "user": {"login": "reviewer1"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updated models.ReviewTask
+	db.Where("id = ?", "preassign-task-1").First(&updated)
+	assert.Contains(t, updated.Reviewers, "U_R1",
+		"プールメンバー (reviewer1=U_R1) が翌朝前に commented した場合、task.Reviewers に事前アサインされるべき")
+	assert.Equal(t, "U_R1", updated.Reviewer,
+		"task.Reviewer が空だった場合、事前アサイン時に埋める")
+}
+
+func TestHandleReviewSubmittedEvent_NonPoolMemberCommentDoesNotPreAssign(t *testing.T) {
+	db := setupTestDB(t)
+	setupPreAssignTestEnv(t)
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// プールに U_R1 のみ登録。コメント者 outsider (U_OUT) は含まれない。
+	config := models.ChannelConfig{
+		ID:                "config-preassign-2",
+		SlackChannelID:    "C_PREASSIGN2",
+		LabelName:         "needs-review",
+		DefaultMentionID:  "UDEFAULT",
+		ReviewerList:      "U_R1",
+		RequiredApprovals: 1,
+		IsActive:          true,
+	}
+	db.Create(&config)
+
+	db.Create(&models.UserMapping{ID: "m-out", GithubUsername: "outsider", SlackUserID: "U_OUT"})
+
+	task := models.ReviewTask{
+		ID:           "preassign-task-2",
+		PRURL:        "https://github.com/owner/repo/pull/601",
+		Repo:         "owner/repo",
+		PRNumber:     601,
+		Title:        "Waiting BH PR",
+		SlackTS:      "1234.6001",
+		SlackChannel: "C_PREASSIGN2",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+		UpdatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 601, "html_url": "https://github.com/owner/repo/pull/601"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "commented", "user": {"login": "outsider"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updated models.ReviewTask
+	db.Where("id = ?", "preassign-task-2").First(&updated)
+	assert.NotContains(t, updated.Reviewers, "U_OUT",
+		"プール外メンバーのコメントで Reviewers が更新されてはいけない")
+	assert.Empty(t, updated.Reviewers, "初期値のまま Reviewers は空であるべき")
+}
+
+func TestHandleReviewSubmittedEvent_PRAuthorCommentDoesNotPreAssign(t *testing.T) {
+	db := setupTestDB(t)
+	setupPreAssignTestEnv(t)
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// 著者自身 (U_AUTHOR) がプールに含まれていても事前アサインしない。
+	config := models.ChannelConfig{
+		ID:                "config-preassign-3",
+		SlackChannelID:    "C_PREASSIGN3",
+		LabelName:         "needs-review",
+		DefaultMentionID:  "UDEFAULT",
+		ReviewerList:      "U_AUTHOR,U_R2",
+		RequiredApprovals: 1,
+		IsActive:          true,
+	}
+	db.Create(&config)
+
+	db.Create(&models.UserMapping{ID: "m-author", GithubUsername: "author", SlackUserID: "U_AUTHOR"})
+
+	task := models.ReviewTask{
+		ID:              "preassign-task-3",
+		PRURL:           "https://github.com/owner/repo/pull/602",
+		Repo:            "owner/repo",
+		PRNumber:        602,
+		Title:           "Waiting BH PR",
+		SlackTS:         "1234.6002",
+		SlackChannel:    "C_PREASSIGN3",
+		Status:          "waiting_business_hours",
+		LabelName:       "needs-review",
+		PRAuthorSlackID: "U_AUTHOR",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		UpdatedAt:       time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 602, "html_url": "https://github.com/owner/repo/pull/602"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "commented", "user": {"login": "author"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updated models.ReviewTask
+	db.Where("id = ?", "preassign-task-3").First(&updated)
+	assert.NotContains(t, updated.Reviewers, "U_AUTHOR",
+		"PR 著者自身のコメントでは事前アサインしない")
+	assert.Empty(t, updated.Reviewers, "Reviewers は空のままであるべき")
+}
+
+func TestHandleReviewSubmittedEvent_DuplicateCommentDoesNotDoubleAssign(t *testing.T) {
+	db := setupTestDB(t)
+	setupPreAssignTestEnv(t)
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	config := models.ChannelConfig{
+		ID:                "config-preassign-4",
+		SlackChannelID:    "C_PREASSIGN4",
+		LabelName:         "needs-review",
+		DefaultMentionID:  "UDEFAULT",
+		ReviewerList:      "U_R1,U_R2",
+		RequiredApprovals: 2,
+		IsActive:          true,
+	}
+	db.Create(&config)
+
+	db.Create(&models.UserMapping{ID: "m1", GithubUsername: "reviewer1", SlackUserID: "U_R1"})
+
+	task := models.ReviewTask{
+		ID:           "preassign-task-4",
+		PRURL:        "https://github.com/owner/repo/pull/603",
+		Repo:         "owner/repo",
+		PRNumber:     603,
+		Title:        "Waiting BH PR",
+		SlackTS:      "1234.6003",
+		SlackChannel: "C_PREASSIGN4",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+		UpdatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 603, "html_url": "https://github.com/owner/repo/pull/603"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "commented", "user": {"login": "reviewer1"}}
+	}`
+
+	// 1回目のコメント
+	{
+		req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GitHub-Event", "pull_request_review")
+		w := httptest.NewRecorder()
+		router := gin.Default()
+		router.POST("/webhook", HandleGitHubWebhook(db))
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// status を waiting_business_hours に戻す (PR1 マージ後の挙動を想定)
+	db.Model(&models.ReviewTask{}).Where("id = ?", "preassign-task-4").
+		Update("status", "waiting_business_hours")
+
+	// 2回目のコメント (同じ人から)
+	{
+		req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GitHub-Event", "pull_request_review")
+		w := httptest.NewRecorder()
+		router := gin.Default()
+		router.POST("/webhook", HandleGitHubWebhook(db))
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	var updated models.ReviewTask
+	db.Where("id = ?", "preassign-task-4").First(&updated)
+	// Reviewers が "U_R1,U_R1" のような重複にならないこと
+	ids := strings.Split(updated.Reviewers, ",")
+	count := 0
+	for _, id := range ids {
+		if strings.TrimSpace(id) == "U_R1" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "同じプールメンバーが2回コメントしても Reviewers に1回しか含まれない")
+}
+
+func TestHandleReviewSubmittedEvent_PreAssignCappedAtRequiredApprovals(t *testing.T) {
+	db := setupTestDB(t)
+	setupPreAssignTestEnv(t)
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// RequiredApprovals=1。既に U_R1 が事前アサイン済みの状態で U_R2 がコメントしても追加しない。
+	config := models.ChannelConfig{
+		ID:                "config-preassign-5",
+		SlackChannelID:    "C_PREASSIGN5",
+		LabelName:         "needs-review",
+		DefaultMentionID:  "UDEFAULT",
+		ReviewerList:      "U_R1,U_R2",
+		RequiredApprovals: 1,
+		IsActive:          true,
+	}
+	db.Create(&config)
+
+	db.Create(&models.UserMapping{ID: "m2", GithubUsername: "reviewer2", SlackUserID: "U_R2"})
+
+	task := models.ReviewTask{
+		ID:           "preassign-task-5",
+		PRURL:        "https://github.com/owner/repo/pull/604",
+		Repo:         "owner/repo",
+		PRNumber:     604,
+		Title:        "Waiting BH PR",
+		SlackTS:      "1234.6004",
+		SlackChannel: "C_PREASSIGN5",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		Reviewer:     "U_R1",
+		Reviewers:    "U_R1",
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+		UpdatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 604, "html_url": "https://github.com/owner/repo/pull/604"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "commented", "user": {"login": "reviewer2"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updated models.ReviewTask
+	db.Where("id = ?", "preassign-task-5").First(&updated)
+	assert.NotContains(t, updated.Reviewers, "U_R2",
+		"requiredApprovals を超える事前アサインは行わない")
+	assert.Equal(t, "U_R1", updated.Reviewers, "Reviewers は元の U_R1 のままであるべき")
+}
+
+func TestHandleReviewSubmittedEvent_AwayPoolMemberStillPreAssigned(t *testing.T) {
+	db := setupTestDB(t)
+	setupPreAssignTestEnv(t)
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	config := models.ChannelConfig{
+		ID:                "config-preassign-6",
+		SlackChannelID:    "C_PREASSIGN6",
+		LabelName:         "needs-review",
+		DefaultMentionID:  "UDEFAULT",
+		ReviewerList:      "U_R1,U_R2",
+		RequiredApprovals: 1,
+		IsActive:          true,
+	}
+	db.Create(&config)
+
+	db.Create(&models.UserMapping{ID: "m1", GithubUsername: "reviewer1", SlackUserID: "U_R1"})
+
+	// U_R1 を Away に設定
+	db.Create(&models.ReviewerAvailability{
+		ID:          "avail-1",
+		SlackUserID: "U_R1",
+	})
+
+	task := models.ReviewTask{
+		ID:           "preassign-task-6",
+		PRURL:        "https://github.com/owner/repo/pull/605",
+		Repo:         "owner/repo",
+		PRNumber:     605,
+		Title:        "Waiting BH PR",
+		SlackTS:      "1234.6005",
+		SlackChannel: "C_PREASSIGN6",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+		UpdatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 605, "html_url": "https://github.com/owner/repo/pull/605"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "commented", "user": {"login": "reviewer1"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updated models.ReviewTask
+	db.Where("id = ?", "preassign-task-6").First(&updated)
+	assert.Contains(t, updated.Reviewers, "U_R1",
+		"Away ステータスでもコメントしてる = 本人が動いてるため事前アサイン対象に含める")
+}

--- a/handlers/webhook_test.go
+++ b/handlers/webhook_test.go
@@ -1512,6 +1512,124 @@ func TestHandleReviewSubmittedEvent_SnoozedTaskCompletedOnChangesRequested(t *te
 	assert.Equal(t, "completed", updatedTask.Status, "Snoozed task should also be completed after changes_requested review")
 }
 
+// --- Tests ensuring waiting_business_hours tasks are NOT completed by comment / changes_requested ---
+// Regression: previously a single comment from anyone before the next business morning would
+// flip waiting_business_hours -> completed and cancel the scheduled reviewer mention.
+
+func TestHandleReviewSubmittedEvent_WaitingBusinessHoursTaskPreservedOnComment(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	task := models.ReviewTask{
+		ID:           "waiting-bh-comment-task",
+		PRURL:        "https://github.com/owner/repo/pull/500",
+		Repo:         "owner/repo",
+		PRNumber:     500,
+		Title:        "Waiting Business Hours PR",
+		SlackTS:      "1234.5500",
+		SlackChannel: "C_WAITING_BH",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+		UpdatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 500, "html_url": "https://github.com/owner/repo/pull/500"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "commented", "user": {"login": "reviewer1"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "waiting-bh-comment-task").First(&updatedTask)
+	assert.Equal(t, "waiting_business_hours", updatedTask.Status,
+		"waiting_business_hours task must NOT be completed by a comment review; the next-morning mention must still fire")
+}
+
+func TestHandleReviewSubmittedEvent_WaitingBusinessHoursTaskPreservedOnChangesRequested(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	task := models.ReviewTask{
+		ID:           "waiting-bh-changes-task",
+		PRURL:        "https://github.com/owner/repo/pull/501",
+		Repo:         "owner/repo",
+		PRNumber:     501,
+		Title:        "Waiting Business Hours PR",
+		SlackTS:      "1234.5501",
+		SlackChannel: "C_WAITING_BH2",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+		UpdatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 501, "html_url": "https://github.com/owner/repo/pull/501"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "changes_requested", "user": {"login": "reviewer1"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "waiting-bh-changes-task").First(&updatedTask)
+	assert.Equal(t, "waiting_business_hours", updatedTask.Status,
+		"waiting_business_hours task must NOT be completed by a changes_requested review; the next-morning mention must still fire")
+}
+
 // --- Tests for snoozed tasks becoming completed when fully approved ---
 
 func TestHandleReviewSubmittedEvent_SnoozedTaskCompletedOnFullApproval(t *testing.T) {

--- a/handlers/webhook_test.go
+++ b/handlers/webhook_test.go
@@ -1571,6 +1571,7 @@ func TestHandleReviewSubmittedEvent_WaitingBusinessHoursTaskPreservedOnComment(t
 	db.Where("id = ?", "waiting-bh-comment-task").First(&updatedTask)
 	assert.Equal(t, "waiting_business_hours", updatedTask.Status,
 		"waiting_business_hours task must NOT be completed by a comment review; the next-morning mention must still fire")
+	assert.True(t, gock.IsDone(), "all Slack mocks should be consumed (review-completed notification must fire)")
 }
 
 func TestHandleReviewSubmittedEvent_WaitingBusinessHoursTaskPreservedOnChangesRequested(t *testing.T) {
@@ -1628,6 +1629,233 @@ func TestHandleReviewSubmittedEvent_WaitingBusinessHoursTaskPreservedOnChangesRe
 	db.Where("id = ?", "waiting-bh-changes-task").First(&updatedTask)
 	assert.Equal(t, "waiting_business_hours", updatedTask.Status,
 		"waiting_business_hours task must NOT be completed by a changes_requested review; the next-morning mention must still fire")
+	assert.True(t, gock.IsDone(), "all Slack mocks should be consumed (review-completed notification must fire)")
+}
+
+// Mixed-state regression: when a single channel/PR has both a waiting_business_hours task and an
+// in_review task, a comment / changes_requested must complete only the in_review one and leave
+// waiting_business_hours intact so the next-morning mention still fires.
+
+func TestHandleReviewSubmittedEvent_WaitingBusinessHoursAndInReview_MixedOnComment(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// Older in_review task
+	oldInReview := models.ReviewTask{
+		ID:           "mixed-comment-in-review",
+		PRURL:        "https://github.com/owner/repo/pull/700",
+		Repo:         "owner/repo",
+		PRNumber:     700,
+		Title:        "Mixed PR",
+		SlackTS:      "1234.7000",
+		SlackChannel: "C_MIXED_COMMENT",
+		Status:       "in_review",
+		Reviewer:     "UREVIEWER",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-3 * time.Hour),
+		UpdatedAt:    time.Now().Add(-3 * time.Hour),
+	}
+	db.Create(&oldInReview)
+
+	// Newer waiting_business_hours task (this becomes latestTask in the per-channel selection)
+	newWaiting := models.ReviewTask{
+		ID:           "mixed-comment-waiting",
+		PRURL:        "https://github.com/owner/repo/pull/700",
+		Repo:         "owner/repo",
+		PRNumber:     700,
+		Title:        "Mixed PR",
+		SlackTS:      "1234.7001",
+		SlackChannel: "C_MIXED_COMMENT",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-1 * time.Hour),
+		UpdatedAt:    time.Now().Add(-1 * time.Hour),
+	}
+	db.Create(&newWaiting)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 700, "html_url": "https://github.com/owner/repo/pull/700"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "commented", "user": {"login": "reviewer1"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var waitingAfter, inReviewAfter models.ReviewTask
+	db.Where("id = ?", "mixed-comment-waiting").First(&waitingAfter)
+	db.Where("id = ?", "mixed-comment-in-review").First(&inReviewAfter)
+
+	assert.Equal(t, "waiting_business_hours", waitingAfter.Status,
+		"waiting_business_hours task must be preserved when coexisting with in_review")
+	assert.Equal(t, "completed", inReviewAfter.Status,
+		"in_review task must be completed to stop reminders")
+	assert.True(t, gock.IsDone(), "review-completed notification must fire exactly once")
+}
+
+func TestHandleReviewSubmittedEvent_WaitingBusinessHoursAndInReview_MixedOnChangesRequested(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	oldInReview := models.ReviewTask{
+		ID:           "mixed-changes-in-review",
+		PRURL:        "https://github.com/owner/repo/pull/701",
+		Repo:         "owner/repo",
+		PRNumber:     701,
+		Title:        "Mixed PR",
+		SlackTS:      "1234.7010",
+		SlackChannel: "C_MIXED_CHANGES",
+		Status:       "in_review",
+		Reviewer:     "UREVIEWER",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-3 * time.Hour),
+		UpdatedAt:    time.Now().Add(-3 * time.Hour),
+	}
+	db.Create(&oldInReview)
+
+	newWaiting := models.ReviewTask{
+		ID:           "mixed-changes-waiting",
+		PRURL:        "https://github.com/owner/repo/pull/701",
+		Repo:         "owner/repo",
+		PRNumber:     701,
+		Title:        "Mixed PR",
+		SlackTS:      "1234.7011",
+		SlackChannel: "C_MIXED_CHANGES",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-1 * time.Hour),
+		UpdatedAt:    time.Now().Add(-1 * time.Hour),
+	}
+	db.Create(&newWaiting)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 701, "html_url": "https://github.com/owner/repo/pull/701"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "changes_requested", "user": {"login": "reviewer1"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var waitingAfter, inReviewAfter models.ReviewTask
+	db.Where("id = ?", "mixed-changes-waiting").First(&waitingAfter)
+	db.Where("id = ?", "mixed-changes-in-review").First(&inReviewAfter)
+
+	assert.Equal(t, "waiting_business_hours", waitingAfter.Status,
+		"waiting_business_hours task must be preserved when coexisting with in_review")
+	assert.Equal(t, "completed", inReviewAfter.Status,
+		"in_review task must be completed to stop reminders")
+	assert.True(t, gock.IsDone(), "review-completed notification must fire exactly once")
+}
+
+// Companion to the preservation tests above: full approval IS expected to complete
+// waiting_business_hours, because the PR is fully approved and no further review is needed.
+// This test pins the intentional asymmetry between the approved branch and the
+// commented/changes_requested branch.
+
+func TestHandleReviewSubmittedEvent_WaitingBusinessHoursTaskCompletedOnFullApproval(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// requiredApprovals = 1 (default), so a single approval = fully approved
+	task := models.ReviewTask{
+		ID:           "waiting-bh-approved",
+		PRURL:        "https://github.com/owner/repo/pull/702",
+		Repo:         "owner/repo",
+		PRNumber:     702,
+		Title:        "Waiting Business Hours PR",
+		SlackTS:      "1234.7020",
+		SlackChannel: "C_WAITING_APPROVED",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now().Add(-2 * time.Hour),
+		UpdatedAt:    time.Now().Add(-2 * time.Hour),
+	}
+	db.Create(&task)
+
+	payload := `{
+		"action": "submitted",
+		"pull_request": {"number": 702, "html_url": "https://github.com/owner/repo/pull/702"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"review": {"state": "approved", "user": {"login": "reviewer1"}}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request_review")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "waiting-bh-approved").First(&updatedTask)
+	assert.Equal(t, "completed", updatedTask.Status,
+		"waiting_business_hours task SHOULD be completed on full approval (no further review needed)")
 }
 
 // --- Tests for snoozed tasks becoming completed when fully approved ---

--- a/services/tasks.go
+++ b/services/tasks.go
@@ -79,22 +79,39 @@ func CheckBusinessHoursTasks(db *gorm.DB) {
 		}
 		reviewersStr := strings.Join(reviewerIDs, ",")
 
-		// Send business hours notification to thread
+		// CAS-like update: skip if preAssignPoolCommenter (or any other writer) updated this
+		// task since we read it. The next ticker pass will re-read the latest reviewers and
+		// fill in the remaining slots. Without this guard, the in-memory `task.Reviewers`
+		// can clobber a freshly pre-assigned reviewer.
+		oldUpdatedAt := task.UpdatedAt
+		updateResult := db.Model(&models.ReviewTask{}).
+			Where("id = ? AND status = ? AND updated_at = ?", task.ID, "waiting_business_hours", oldUpdatedAt).
+			Updates(map[string]interface{}{
+				"status":     "in_review",
+				"reviewer":   reviewerID,
+				"reviewers":  reviewersStr,
+				"updated_at": time.Now(),
+			})
+		if updateResult.Error != nil {
+			log.Printf("task status update error (task: %s): %v", task.ID, updateResult.Error)
+			continue
+		}
+		if updateResult.RowsAffected == 0 {
+			log.Printf("CAS conflict on business hours activation, will retry next tick: id=%s", task.ID)
+			continue
+		}
+
+		// Send business hours notification to thread (only after the DB CAS succeeded so we
+		// don't notify for a task that another writer has already activated).
 		if err := PostBusinessHoursNotificationToThread(task, config.DefaultMentionID); err != nil {
 			log.Printf("business hours notification error (task: %s): %v", task.ID, err)
 			continue
 		}
 
-		// Update task status
+		// Reflect the committed values in the in-memory copy used for downstream notifications.
 		task.Status = "in_review"
 		task.Reviewer = reviewerID
 		task.Reviewers = reviewersStr
-		task.UpdatedAt = time.Now()
-
-		if err := db.Save(&task).Error; err != nil {
-			log.Printf("task status update error (task: %s): %v", task.ID, err)
-			continue
-		}
 
 		log.Printf("waiting_business_hours task activated: %s", task.ID)
 

--- a/services/tasks.go
+++ b/services/tasks.go
@@ -42,16 +42,37 @@ func CheckBusinessHoursTasks(db *gorm.DB) {
 			continue // Outside business hours, skip processing
 		}
 
-		// Randomly select reviewers (excluding PR author)
+		// 既に事前アサイン済みのレビュワー (プールメンバーが翌朝前にコメントしたケース) を尊重する。
+		existingReviewerIDs := []string{}
+		for _, id := range strings.Split(task.Reviewers, ",") {
+			if trimmed := strings.TrimSpace(id); trimmed != "" {
+				existingReviewerIDs = append(existingReviewerIDs, trimmed)
+			}
+		}
+
+		// Randomly select reviewers (excluding PR author and already pre-assigned reviewers)
 		excludeIDs := []string{}
 		if task.PRAuthorSlackID != "" {
 			excludeIDs = append(excludeIDs, task.PRAuthorSlackID)
 		}
+		excludeIDs = append(excludeIDs, existingReviewerIDs...)
+
 		requiredApprovals := config.RequiredApprovals
 		if requiredApprovals <= 0 {
 			requiredApprovals = 1
 		}
-		reviewerIDs := SelectRandomReviewers(db, task.SlackChannel, labelName, requiredApprovals, excludeIDs)
+
+		needed := requiredApprovals - len(existingReviewerIDs)
+		var reviewerIDs []string
+		if needed > 0 {
+			selected := SelectRandomReviewers(db, task.SlackChannel, labelName, needed, excludeIDs)
+			reviewerIDs = append(reviewerIDs, existingReviewerIDs...)
+			reviewerIDs = append(reviewerIDs, selected...)
+		} else {
+			// 事前アサインだけで requiredApprovals を満たしているのでランダム選出はスキップ。
+			reviewerIDs = existingReviewerIDs
+		}
+
 		reviewerID := ""
 		if len(reviewerIDs) > 0 {
 			reviewerID = reviewerIDs[0]

--- a/services/tasks_test.go
+++ b/services/tasks_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"os"
 	"slack-review-notify/models"
+	"strings"
 	"testing"
 	"time"
 
@@ -423,4 +424,145 @@ func TestCleanupExpiredAvailability(t *testing.T) {
 	// Expired record should be deleted
 	db.Unscoped().Model(&models.ReviewerAvailability{}).Where("id = ?", "expired-away").Count(&count)
 	assert.Equal(t, int64(0), count)
+}
+
+// TestCheckBusinessHoursTasks_HonorsExistingReviewers は、
+// waiting_business_hours の task に既にレビュワーが事前アサインされている場合、
+// SelectRandomReviewers はその人を除外し、不足分のみ選出することを確認する。
+func TestCheckBusinessHoursTasks_HonorsExistingReviewers(t *testing.T) {
+	db := setupTestDB(t)
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	// chat.postMessage は複数回呼ばれるので Persist
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// RequiredApprovals=2, プールに 3人
+	config := models.ChannelConfig{
+		ID:                "cfg-honors",
+		SlackChannelID:    "C_HONORS",
+		LabelName:         "needs-review",
+		DefaultMentionID:  "UDEFAULT",
+		ReviewerList:      "U_R1,U_R2,U_R3",
+		RequiredApprovals: 2,
+		IsActive:          true,
+		// BusinessHours 未設定 → 常に within business hours
+	}
+	db.Create(&config)
+
+	// U_R1 だけ事前アサイン済み
+	task := models.ReviewTask{
+		ID:           "honors-task",
+		PRURL:        "https://github.com/owner/repo/pull/700",
+		Repo:         "owner/repo",
+		PRNumber:     700,
+		Title:        "Test PR",
+		SlackTS:      "1234.7000",
+		SlackChannel: "C_HONORS",
+		Reviewer:     "U_R1",
+		Reviewers:    "U_R1",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	CheckBusinessHoursTasks(db)
+
+	var updated models.ReviewTask
+	db.First(&updated, "id = ?", "honors-task")
+
+	assert.Equal(t, "in_review", updated.Status, "business hours に入ったので in_review へ遷移")
+	// Reviewers は "U_R1,X" の形式で、X は U_R2 か U_R3 のどちらか
+	ids := splitNonEmptyForTest(updated.Reviewers)
+	assert.Len(t, ids, 2, "RequiredApprovals=2 分のレビュワーが設定されるべき")
+	assert.Contains(t, ids, "U_R1", "事前アサイン済みの U_R1 は維持されるべき")
+	assert.Equal(t, "U_R1", ids[0], "先頭は事前アサインの U_R1")
+	// 2人目は U_R2 か U_R3
+	second := ids[1]
+	assert.Contains(t, []string{"U_R2", "U_R3"}, second, "不足分はプールから選出される")
+	assert.NotEqual(t, "U_R1", second, "SelectRandomReviewers は事前アサイン済み U_R1 を除外する")
+}
+
+// TestCheckBusinessHoursTasks_FullyPreAssignedSkipsRandomSelect は、
+// RequiredApprovals を既に満たす数の事前アサインがあれば SelectRandomReviewers を呼ばず、
+// 事前アサイン分だけでメンション対象とすることを確認する。
+func TestCheckBusinessHoursTasks_FullyPreAssignedSkipsRandomSelect(t *testing.T) {
+	db := setupTestDB(t)
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// RequiredApprovals=1, プールに 2人
+	config := models.ChannelConfig{
+		ID:                "cfg-fully",
+		SlackChannelID:    "C_FULLY",
+		LabelName:         "needs-review",
+		DefaultMentionID:  "UDEFAULT",
+		ReviewerList:      "U_R1,U_R2",
+		RequiredApprovals: 1,
+		IsActive:          true,
+	}
+	db.Create(&config)
+
+	// U_R1 が事前アサイン済み、RequiredApprovals=1 を満たしている
+	task := models.ReviewTask{
+		ID:           "fully-task",
+		PRURL:        "https://github.com/owner/repo/pull/701",
+		Repo:         "owner/repo",
+		PRNumber:     701,
+		Title:        "Test PR",
+		SlackTS:      "1234.7001",
+		SlackChannel: "C_FULLY",
+		Reviewer:     "U_R1",
+		Reviewers:    "U_R1",
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	CheckBusinessHoursTasks(db)
+
+	var updated models.ReviewTask
+	db.First(&updated, "id = ?", "fully-task")
+
+	assert.Equal(t, "in_review", updated.Status, "business hours に入ったので in_review へ遷移")
+	assert.Equal(t, "U_R1", updated.Reviewers, "既に RequiredApprovals を満たしているため U_R1 のみ")
+	assert.Equal(t, "U_R1", updated.Reviewer, "Reviewer も U_R1 で固定")
+}
+
+// splitNonEmptyForTest はテスト用のカンマ区切りユーティリティ。空要素は除外する。
+func splitNonEmptyForTest(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var result []string
+	for _, p := range strings.Split(s, ",") {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
## マージ順序

1. 先に PR [#94](https://github.com/haruotsu/slack-review-notify/pull/94) をマージする
2. その後に本PRをマージする

本PRのブランチには Critical 対応として PR #94 を merge で取り込んでいる。
そのため PR #94 マージ前の段階でも PR #95 単独で機能テストが通る状態にある。
差分には PR #94 の変更も含まれるが、PR #94 マージ後は git が重複 commit を自動でスキップ判定する。


## 背景

PR1 ([#94](https://github.com/haruotsu/slack-review-notify/pull/94)) で次のバグ修正を予定しています。`waiting_business_hours` のタスクに対し commented / changes_requested を受けても `completed` 化しないようにする挙動修正です。

本PRはその上に乗る機能拡張です。「翌朝メンション前にプール所属メンバーがレビューを残したら、その人を翌朝の指名対象に自動で含める」挙動を実装します。

本PRは PR1 ([#94](https://github.com/haruotsu/slack-review-notify/pull/94)) のマージ後に効果を発揮します。先にPR1をマージしてから本PRをマージしてください。

## 仕様

| # | 論点 | 確定方針 |
|---|---|---|
| 1 | プール外の人がコメントした場合 | 事前アサインしない。既存どおり翌朝ランダム |
| 2 | requiredApprovals=2 で1人プール内コメント | その人とランダム選出のもう1人 |
| 3 | Away中のプール所属者がコメント | Awayを無視して含める（本人が動いているため） |
| 4 | 同じ人が複数回コメント | 重複排除 |
| 5 | プール内コメント者が requiredApprovals 超え | 上限で打ち切り |

## 実装内容

### handlers/webhook.go

commented / changes_requested の default 分岐を変更しました。`latestTask.Status == "waiting_business_hours"` の場合のみ `preAssignPoolCommenter` を呼び出します。

`preAssignPoolCommenter` は以下の条件を満たすとき `task.Reviewers` にコメント者を追加します。

- `reviewerSlackID` が空でない（UserMapping 登録済み）
- コメント者が PR 著者と異なる
- ChannelConfig の `ReviewerList` にコメント者が含まれる
- `task.Reviewers` にまだ含まれていない（重複排除）
- 既存 reviewers 数が `requiredApprovals` 未満（上限打ち切り）

CAS 風の条件 (`WHERE id = ? AND reviewers = ? AND status = ?`) で UPDATE して、同時更新時のロストアップデートを防ぎます。

### services/tasks.go

`CheckBusinessHoursTasks` を修正しました。既に `task.Reviewers` に事前アサイン済みのレビュワーがいる場合、`SelectRandomReviewers` は不足分のみ選出します。`requiredApprovals` を既に満たしている場合は `SelectRandomReviewers` を呼ばずに既存分だけで通知します。

## テスト

### 追加 (計8件)

`handlers/webhook_test.go`:

- `TestHandleReviewSubmittedEvent_PoolMemberCommentPreAssignsToWaitingBusinessHours`
- `TestHandleReviewSubmittedEvent_NonPoolMemberCommentDoesNotPreAssign`
- `TestHandleReviewSubmittedEvent_PRAuthorCommentDoesNotPreAssign`
- `TestHandleReviewSubmittedEvent_DuplicateCommentDoesNotDoubleAssign`
- `TestHandleReviewSubmittedEvent_PreAssignCappedAtRequiredApprovals`
- `TestHandleReviewSubmittedEvent_AwayPoolMemberStillPreAssigned`

`services/tasks_test.go`:

- `TestCheckBusinessHoursTasks_HonorsExistingReviewers`
- `TestCheckBusinessHoursTasks_FullyPreAssignedSkipsRandomSelect`

### 実行結果

- [x] `go build ./...` 通過
- [x] `go vet ./...` 通過
- [x] `go test ./...` 通過（既存テスト含めて全て通過）

## Out of scope

- 翌朝通知メッセージ上で「事前アサインされたレビュワー」を特別扱いする表示改修
- partial approve 時の `SelectRandomReviewers` が `approved_by` を除外していない問題（別PR候補）
