### PR TITLE
fix: help コマンドの action_id 重複で invalid_command_response になる障害を修正

### DIFF
--- a/handlers/command.go
+++ b/handlers/command.go
@@ -374,10 +374,14 @@ func showHelp(c *gin.Context, db *gorm.DB, channelID, lang string) {
 		})
 		row = make([]map[string]interface{}, 0, buttonsPerRow)
 	}
-	for _, cfg := range configs {
+	// action_id must be unique within a single actions block (Slack rejects
+	// duplicates with invalid_command_response). All buttons share the
+	// open_settings route prefix; the handler matches on HasPrefix and reads
+	// the target label from the button's value.
+	for i, cfg := range configs {
 		row = append(row, services.CreateButton(
 			fmt.Sprintf(t("modal.open_button.edit"), cfg.LabelName),
-			"open_settings",
+			fmt.Sprintf("%s:%d", actionOpenSettings, i),
 			cfg.LabelName,
 			"",
 		))
@@ -388,7 +392,7 @@ func showHelp(c *gin.Context, db *gorm.DB, channelID, lang string) {
 	// Always include a "create new" button so users with no existing config can still get in.
 	row = append(row, services.CreateButton(
 		t("modal.open_button.new"),
-		"open_settings",
+		actionOpenSettings+":new",
 		services.CreateNewLabelSentinel,
 		"primary",
 	))

--- a/handlers/settings_modal_test.go
+++ b/handlers/settings_modal_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -434,6 +435,36 @@ func TestHandleSlackCommand_HelpListsPerLabelButtons(t *testing.T) {
 	assert.Contains(t, body, "urgent")
 	// Create-new button uses the sentinel as its value.
 	assert.Contains(t, body, "__create_new__")
+
+	// Regression guard: Slack's Block Kit rejects responses whose buttons share
+	// the same action_id within a single actions block (invalid_command_response).
+	// Make sure every element's action_id is unique within its containing block.
+	var parsed struct {
+		Blocks []struct {
+			Type     string `json:"type"`
+			Elements []struct {
+				ActionID string `json:"action_id"`
+			} `json:"elements"`
+		} `json:"blocks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	for i, b := range parsed.Blocks {
+		if b.Type != "actions" {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, el := range b.Elements {
+			if el.ActionID == "" {
+				continue
+			}
+			if seen[el.ActionID] {
+				t.Errorf("blocks[%d] has duplicate action_id %q within one actions block; Slack rejects this with invalid_command_response", i, el.ActionID)
+			}
+			seen[el.ActionID] = true
+		}
+	}
 }
 
 // TestHandleSlackAction_ViewSubmission_DeleteThenRecreate verifies the user can

--- a/handlers/slack.go
+++ b/handlers/slack.go
@@ -17,6 +17,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// actionOpenSettings is the action_id route prefix for the "Open Settings"
+// button family rendered by the help command. Each button instance gets a
+// unique suffix (":<index>" or ":new") so Slack's per-block action_id
+// uniqueness rule isn't violated.
+const actionOpenSettings = "open_settings"
+
 type SlackActionPayload struct {
 	Type      string `json:"type"`
 	TriggerID string `json:"trigger_id,omitempty"`
@@ -104,7 +110,11 @@ func HandleSlackAction(db *gorm.DB) gin.HandlerFunc {
 		actionID := payload.Actions[0].ActionID
 
 		// Handle "Open Settings" button: opens the settings modal via views.open.
-		if actionID == "open_settings" {
+		// The help command renders one button per label, each with a unique
+		// action_id like "open_settings:<index>" (Slack requires action_id
+		// uniqueness within an actions block). Route on prefix; the target
+		// label is carried in the button's value field, not the action_id.
+		if actionID == actionOpenSettings || strings.HasPrefix(actionID, actionOpenSettings+":") {
 			handleOpenSettings(c, db, payload)
 			return
 		}


### PR DESCRIPTION
## Summary
本番障害 hotfix。`/slack-review-notify help` が Slack 側で `invalid_command_response` として拒否される問題を解消します。

## 原因
PR #98 でラベルごとに「設定編集」ボタンを並べた結果、同一の `actions` block 内に複数のボタンが同じ `action_id="open_settings"` を持つようになっていた。Slack の Block Kit は **1ブロック内で `action_id` のユニーク性を強制する**（"Should be unique" と書かれているがレスポンス側では実質 must）ため、レスポンス全体が `invalid_command_response` として拒否されていた。

旧コードはこの button が1個しか無かったため、潜在化していた。

## 修正
- 各「設定編集」ボタンに `open_settings:<index>` / `open_settings:new` のユニーク `action_id` を付与
- `HandleSlackAction` を `actionID == "open_settings" || HasPrefix("open_settings:")` の prefix ルーティングに変更。target ラベルは従来どおり `button.value` から取得するので互換
- regression guard として、help レスポンスの JSON をパースし、同一 actions block 内の `action_id` が全て uniq であることを検証するアサーションを追加

## Test plan
- [x] `go test ./... -count=1` 全 PASS
- [x] `go vet ./...` 警告なし
- [x] `golangci-lint run ./...` クリーン
- [x] 追加した `TestHandleSlackCommand_HelpListsPerLabelButtons` の regression guard が修正前の実装で fail し、修正後に pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)