### PR TITLE
fix: set-mention 未設定でも壊れない仕様にし、help テキストを実態に合わせる

### DIFF
--- a/handlers/commands_test.go
+++ b/handlers/commands_test.go
@@ -60,8 +60,12 @@ func TestHandleSlackCommand_Help(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 	assert.Contains(t, w.Body.String(), "Review通知Bot設定コマンド")
 	assert.Contains(t, w.Body.String(), "複数ラベル設定の使い方")
-	assert.Contains(t, w.Body.String(), "初期設定（必須）")
-	assert.Contains(t, w.Body.String(), "この2つを設定しないと通知は送信されません")
+	// Help text now positions repository as the only required setup; set-mention
+	// is moved to the recommended/optional section so the wording shouldn't claim
+	// "両方必須" anymore.
+	assert.Contains(t, w.Body.String(), "対象リポジトリの追加（必須）")
+	assert.Contains(t, w.Body.String(), "推奨設定（任意）")
+	assert.Contains(t, w.Body.String(), "リポジトリが未設定の場合、通知は送信されません")
 	assert.Contains(t, w.Body.String(), "このチャンネルの全ラベル設定を表示")
 	assert.Contains(t, w.Body.String(), "指定ラベルの詳細設定を表示")
 }

--- a/handlers/set_language_test.go
+++ b/handlers/set_language_test.go
@@ -232,7 +232,8 @@ func TestHelp_ReturnsEnglishWhenLanguageIsEn(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 	// Should return English help
 	assert.Contains(t, w.Body.String(), "Review Notification Bot Configuration")
-	assert.Contains(t, w.Body.String(), "Initial Setup (Required)")
+	assert.Contains(t, w.Body.String(), "Initial Setup")
+	assert.Contains(t, w.Body.String(), "Recommended (Optional)")
 	// Should NOT contain Japanese
 	assert.NotContains(t, w.Body.String(), "Review通知Bot設定コマンド")
 }

--- a/i18n/messages_en.go
+++ b/i18n/messages_en.go
@@ -14,15 +14,17 @@ If your label name contains spaces, wrap it in quotes (" or '):
 - Example: /slack-review-notify "needs review" set-mention @team
 - Example: /slack-review-notify 'security review' add-reviewer @security
 
-*Initial Setup (Required)*
-At minimum, the following settings are required to receive notifications:
-:point_right: *1. Set mention target*
-   /slack-review-notify [label-name] set-mention @user
-
-:point_right: *2. Add target repository (important!)*
+*Initial Setup*
+The following repository setting is required to receive notifications:
+:point_right: *Add target repository (required)*
    /slack-review-notify [label-name] add-repo owner/repo
 
-:information_source: Notifications will not be sent without both of these settings
+:information_source: Notifications will not be sent until at least one repository is added.
+
+*Recommended (Optional)*
+:point_right: *Set mention target*
+   /slack-review-notify [label-name] set-mention @user
+   Without this, notifications are still sent — just without an @-mention. Add it when you want to ping a person or team.
 
 *Multiple Label Configuration*
 You can have independent settings for different labels in this channel:
@@ -43,8 +45,10 @@ Specify multiple labels separated by commas to notify only when all labels are p
 • /slack-review-notify [label-name] show - Show detailed settings for specified label
 
 *Required Settings:*
-• /slack-review-notify [label-name] set-mention @user - Set mention target
-• /slack-review-notify [label-name] add-repo owner/repo1,owner/repo2 - Add target repositories
+• /slack-review-notify [label-name] add-repo owner/repo1,owner/repo2 - Add target repositories (required)
+
+*Optional Settings:*
+• /slack-review-notify [label-name] set-mention @user - Set mention target (notifications still go out without it, just without an @-mention)
 
 *Reviewer Management:*
 • /slack-review-notify [label-name] add-reviewer @user1,@user2 - Add reviewers

--- a/i18n/messages_ja.go
+++ b/i18n/messages_ja.go
@@ -14,15 +14,17 @@ var messagesJa = map[string]string{
 - 例: /slack-review-notify "needs review" set-mention @team
 - 例: /slack-review-notify 'security review' add-reviewer @security
 
-*初期設定（必須）*
-通知を受けるには最低限以下の設定が必要です：
-:point_right: *1. メンション先の設定*
-   /slack-review-notify [ラベル名] set-mention @user
-
-:point_right: *2. 対象リポジトリの追加（重要！）*
+*初期設定*
+通知を受けるには以下のリポジトリ設定が必須です:
+:point_right: *対象リポジトリの追加（必須）*
    /slack-review-notify [ラベル名] add-repo owner/repo
 
-:information_source: この2つを設定しないと通知は送信されません
+:information_source: リポジトリが未設定の場合、通知は送信されません。
+
+*推奨設定（任意）*
+:point_right: *メンション先の設定*
+   /slack-review-notify [ラベル名] set-mention @user
+   未設定でも通知は送信されます（メンション無し）。チームに気付かせたい場合に設定してください。
 
 *複数ラベル設定の使い方*
 このチャンネル内で複数の異なるラベルごとに独立した設定を持つことができます:
@@ -43,8 +45,10 @@ var messagesJa = map[string]string{
 • /slack-review-notify [ラベル名] show - 指定ラベルの詳細設定を表示
 
 *必須設定:*
-• /slack-review-notify [ラベル名] set-mention @user - メンション先を設定
-• /slack-review-notify [ラベル名] add-repo owner/repo1,owner/repo2 - 対象リポジトリを追加
+• /slack-review-notify [ラベル名] add-repo owner/repo1,owner/repo2 - 対象リポジトリを追加（必須）
+
+*任意設定:*
+• /slack-review-notify [ラベル名] set-mention @user - メンション先を設定（未設定可。設定するとレビュー依頼通知に @ メンションが付きます）
 
 *レビュワー管理:*
 • /slack-review-notify [ラベル名] add-reviewer @user1,@user2 - レビュワーを追加

--- a/services/slack.go
+++ b/services/slack.go
@@ -110,6 +110,12 @@ func GetSlackUserIDFromGitHub(db *gorm.DB, githubUsername string) string {
 }
 
 func buildMentionText(mentionID string) string {
+	// Empty mention is supported (some channels intentionally don't set a
+	// default mention target). Returning "" instead of "<@>" keeps the
+	// notification message valid Slack markup with just a leading space.
+	if mentionID == "" {
+		return ""
+	}
 	if strings.HasPrefix(mentionID, "subteam^") || strings.HasPrefix(mentionID, "S") {
 		return fmt.Sprintf("<!subteam^%s>", mentionID)
 	}
@@ -150,6 +156,12 @@ func SelectRandomReviewers(db *gorm.DB, channelID string, labelName string, coun
 	}
 
 	if config.ReviewerList == "" {
+		// Falling back to DefaultMentionID is only meaningful when one is
+		// configured. An empty mention here would propagate as a "<@>"
+		// literal downstream, so return an empty slice instead.
+		if config.DefaultMentionID == "" {
+			return []string{}
+		}
 		return []string{config.DefaultMentionID}
 	}
 
@@ -178,6 +190,9 @@ func SelectRandomReviewers(db *gorm.DB, channelID string, labelName string, coun
 	}
 
 	if len(candidates) == 0 {
+		if config.DefaultMentionID == "" {
+			return []string{}
+		}
 		return []string{config.DefaultMentionID}
 	}
 

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -736,6 +736,57 @@ func TestSelectRandomReviewers_InsufficientAfterExclusion(t *testing.T) {
 	assert.Equal(t, "U2", result[0])
 }
 
+// TestBuildMentionText_EmptyReturnsEmpty pins the behavior that an empty
+// mention ID must produce no mention text — not the broken "<@>" literal,
+// which Slack renders as invalid markup. Empty DefaultMentionID is a
+// supported state (some channels intentionally don't set a mention).
+func TestBuildMentionText_EmptyReturnsEmpty(t *testing.T) {
+	if got := buildMentionText(""); got != "" {
+		t.Errorf("buildMentionText(\"\") = %q, want empty string", got)
+	}
+}
+
+// TestSelectRandomReviewers_NoReviewersNoDefault: when both ReviewerList and
+// DefaultMentionID are empty, returning [DefaultMentionID] would push the
+// empty string downstream and produce broken "<@>" mentions in notifications.
+// The function must return an empty slice instead so callers can skip the
+// mention block cleanly.
+func TestSelectRandomReviewers_NoReviewersNoDefault(t *testing.T) {
+	db := setupTestDB(t)
+	db.Create(&models.ChannelConfig{
+		ID:               "noment",
+		SlackChannelID:   "C_NOMENT",
+		LabelName:        "needs-review",
+		DefaultMentionID: "",
+		ReviewerList:     "",
+		IsActive:         true,
+	})
+
+	result := SelectRandomReviewers(db, "C_NOMENT", "needs-review", 1, nil)
+	if len(result) != 0 {
+		t.Errorf("expected empty slice when no reviewers and no default mention, got %v", result)
+	}
+}
+
+// TestSelectRandomReviewers_AllExcludedNoDefault: when every reviewer
+// candidate is excluded AND DefaultMentionID is empty, also return empty.
+func TestSelectRandomReviewers_AllExcludedNoDefault(t *testing.T) {
+	db := setupTestDB(t)
+	db.Create(&models.ChannelConfig{
+		ID:               "allx-nom",
+		SlackChannelID:   "C_ALLX_NOM",
+		LabelName:        "needs-review",
+		DefaultMentionID: "",
+		ReviewerList:     "U1,U2",
+		IsActive:         true,
+	})
+
+	result := SelectRandomReviewers(db, "C_ALLX_NOM", "needs-review", 1, []string{"U1", "U2"})
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %v", result)
+	}
+}
+
 func TestSelectRandomReviewers_AllExcluded(t *testing.T) {
 	db := setupTestDB(t)
 


### PR DESCRIPTION
## Summary
`set-mention` を「必須」と謳いつつ、実際には未設定でも `add-repo` さえあれば通知が飛んでしまい、その通知のメンション部分が `<@>` という壊れた markup になっていた問題を解消します。set-mention は運用によっては不要なので、**ヘルプ上もオプショナル扱い**にし、未設定時の下流挙動も整合させます。

## 変更点
| 箇所 | 変更 |
|---|---|
| `services/slack.go` `buildMentionText` | 空入力なら `""` を返す（従来は `<@>`） |
| `services/slack.go` `SelectRandomReviewers` | reviewer 候補が空 + `DefaultMentionID` も空のとき、`[]string{""}` ではなく `[]string{}` を返す（下流で `<@>` を再生産しない） |
| `i18n/messages_ja.go` / `messages_en.go` `cmd.help` | 「初期設定（必須）」「この2つを設定しないと通知は送信されません」を廃止し、**リポジトリのみ必須**・**set-mention は推奨/任意** という記述へ |
| 既存テスト | 新文言・新挙動に合わせて更新（赤テストで再現 → 緑へ） |

## ユーザ向けの影響
- 既に `set-mention` を入れているチャンネル: 挙動不変
- `set-mention` 未設定のチャンネル: これまで `<@>` という壊れた表示で届いていた通知が、メンション無しの通常メッセージとして届くようになる（実用に耐える状態に）
- DB マイグレーション・スコープ追加・env 変更すべて不要

## Test plan
- [x] `go test ./... -count=1` 全 PASS
- [x] `go vet ./...` 警告なし
- [x] `golangci-lint run ./...` クリーン
- 追加テスト
  - `TestBuildMentionText_EmptyReturnsEmpty`
  - `TestSelectRandomReviewers_NoReviewersNoDefault`
  - `TestSelectRandomReviewers_AllExcludedNoDefault`
- 既存テストの期待文言を新ヘルプ表現に追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)