### PR TITLE
レビュワーのメンションが素の @U… テキストになり機能しない不具合を修正

### DIFF
--- a/i18n/messages_en.go
+++ b/i18n/messages_en.go
@@ -344,9 +344,9 @@ Omitting [label-name] uses the default label "needs-review"`,
 	"notify.review_request.without_creator": "%s *There is a PR to review!*\n\n*PR Title*: %s\n*URL*: <%s>",
 
 	"notify.business_hours_morning":  "🌅 *Good morning!* %s\n\n📋 Please review this PR. %s",
-	"notify.reviewer_in_morning":     "\n\n🎯 *Reviewer*: @%s, please take a look!",
+	"notify.reviewer_in_morning":     "\n\n🎯 *Reviewer*: %s, please take a look!",
 	"notify.reminder":                "%s Would love a review! 👀",
-	"notify.out_of_hours_reminder":   "@%s Would love a review! 👀\n\nOutside business hours - next reminder will be sent on the next business day.",
+	"notify.out_of_hours_reminder":   "%s Would love a review! 👀\n\nOutside business hours - next reminder will be sent on the next business day.",
 
 	"notify.reminder_paused.1h":      "Got it! Pausing reminders for 1 hour!",
 	"notify.reminder_paused.2h":      "Got it! Pausing reminders for 2 hours!",

--- a/i18n/messages_ja.go
+++ b/i18n/messages_ja.go
@@ -344,9 +344,9 @@ var messagesJa = map[string]string{
 	"notify.review_request.without_creator": "%s *レビュー対象のPRがあります！*\n\n*PRタイトル*: %s\n*URL*: <%s>",
 
 	"notify.business_hours_morning":  "🌅 *おはようございます！* %s\n\n📋 こちらのPRのレビューをお願いします。%s",
-	"notify.reviewer_in_morning":     "\n\n🎯 *レビュワー*: @%s さん、よろしくお願いします！",
+	"notify.reviewer_in_morning":     "\n\n🎯 *レビュワー*: %s さん、よろしくお願いします！",
 	"notify.reminder":                "%s レビューしてくれたら嬉しいです...👀",
-	"notify.out_of_hours_reminder":   "@%s レビューしてくれたら嬉しいです...👀\n\n営業時間外のため、次回のリマインドは翌営業日に送信します。",
+	"notify.out_of_hours_reminder":   "%s レビューしてくれたら嬉しいです...👀\n\n営業時間外のため、次回のリマインドは翌営業日に送信します。",
 
 	"notify.reminder_paused.1h":      "はい！1時間リマインドをストップします！",
 	"notify.reminder_paused.2h":      "はい！2時間リマインドをストップします！",

--- a/services/business_hours_activation_test.go
+++ b/services/business_hours_activation_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"os"
+	"slack-review-notify/models"
+	"testing"
+	"time"
+
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+)
+
+// When a task waiting for business hours is activated, the reviewer is selected at
+// activation time. The morning greeting must mention that freshly-selected reviewer,
+// which only works if the reviewer is assigned to the task before the notification is
+// sent. This guards against the notification being posted before the assignment.
+func TestActivateBusinessHoursTask_MorningGreetingMentionsAssignedReviewer(t *testing.T) {
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() { _ = os.Setenv("SLACK_BOT_TOKEN", originalToken) }()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	db := setupTestDB(t)
+
+	config := models.ChannelConfig{
+		ID:               "cfg-activation",
+		SlackChannelID:   "C12345",
+		LabelName:        "needs-review",
+		DefaultMentionID: "U_DEFAULT",
+		ReviewerList:     "UREV1",
+		IsActive:         true,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+	db.Create(&config)
+
+	task := models.ReviewTask{
+		ID:           "task-activation",
+		PRURL:        "https://github.com/owner/repo/pull/1",
+		Repo:         "owner/repo",
+		PRNumber:     1,
+		Title:        "Test PR",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Reviewer:     "", // not yet assigned while waiting for business hours
+		Status:       "waiting_business_hours",
+		LabelName:    "needs-review",
+		Language:     "ja",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	defer gock.Off()
+
+	// The morning greeting ("おはよう") must contain the assigned reviewer mention.
+	// json.Marshal escapes "<@UREV1>" to "<@UREV1>" in the body.
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		BodyString(`おはよう[\s\S]*\\u003c@UREV1\\u003e`).
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// The follow-up "reviewer assigned + change button" message.
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	err := activateBusinessHoursTask(db, task, config, "needs-review")
+	assert.NoError(t, err)
+	assert.True(t, gock.IsDone(), "expected the morning greeting to mention <@UREV1>")
+
+	var updated models.ReviewTask
+	db.First(&updated, "id = ?", "task-activation")
+	assert.Equal(t, "in_review", updated.Status)
+	assert.Equal(t, "UREV1", updated.Reviewer)
+}

--- a/services/reviewer_mention_render_test.go
+++ b/services/reviewer_mention_render_test.go
@@ -1,0 +1,78 @@
+package services
+
+import (
+	"os"
+	"slack-review-notify/models"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+)
+
+// A reviewer stored as a resolved Slack user ID (e.g. "U05JSSXA6RL") must be
+// posted as the mention markup "<@U05JSSXA6RL>", not the bare "@U05JSSXA6RL"
+// literal — Slack only turns the former into a clickable mention. These tests
+// pin the markup the bot actually sends for reminder/morning notifications.
+
+func TestSendOutOfHoursReminderMessage_RendersReviewerAsMention(t *testing.T) {
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() { _ = os.Setenv("SLACK_BOT_TOKEN", originalToken) }()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	// The mock only matches when the posted body contains the proper mention
+	// markup. If the bot posts the bare "@U05JSSXA6RL" literal, the request
+	// fails to match and SendOutOfHoursReminderMessage returns an error.
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		// json.Marshal HTML-escapes "<" / ">" to < / >, so the
+		// proper mention "<@U05JSSXA6RL>" appears in the body as
+		// "<@U05JSSXA6RL>". The leading < is what distinguishes
+		// a real mention from the broken bare "@U05JSSXA6RL" literal.
+		BodyString(`\\u003c@U05JSSXA6RL\\u003e`).
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	task := models.ReviewTask{
+		ID:           "task-mention",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Reviewer:     "U05JSSXA6RL",
+		Status:       "in_review",
+	}
+
+	err := SendOutOfHoursReminderMessage(nil, task)
+	assert.NoError(t, err)
+	assert.True(t, gock.IsDone(), "expected a chat.postMessage containing <@U05JSSXA6RL>")
+}
+
+func TestPostBusinessHoursNotificationToThread_RendersReviewerAsMention(t *testing.T) {
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() { _ = os.Setenv("SLACK_BOT_TOKEN", originalToken) }()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		// json.Marshal HTML-escapes "<" / ">" to < / >, so the
+		// proper mention "<@U05JSSXA6RL>" appears in the body as
+		// "<@U05JSSXA6RL>". The leading < is what distinguishes
+		// a real mention from the broken bare "@U05JSSXA6RL" literal.
+		BodyString(`\\u003c@U05JSSXA6RL\\u003e`).
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	task := models.ReviewTask{
+		ID:           "task-morning",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Reviewer:     "U05JSSXA6RL",
+		Status:       "in_review",
+	}
+
+	err := PostBusinessHoursNotificationToThread(task, "UDEFAULT")
+	assert.NoError(t, err)
+	assert.True(t, gock.IsDone(), "expected a chat.postMessage containing <@U05JSSXA6RL>")
+}

--- a/services/reviewer_mention_render_test.go
+++ b/services/reviewer_mention_render_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// A reviewer stored as a resolved Slack user ID (e.g. "U05JSSXA6RL") must be
-// posted as the mention markup "<@U05JSSXA6RL>", not the bare "@U05JSSXA6RL"
-// literal — Slack only turns the former into a clickable mention. These tests
-// pin the markup the bot actually sends for reminder/morning notifications.
+// A reviewer's Slack user ID must be posted as "<@U…>" so Slack renders a
+// clickable mention; "@U…" alone stays plain text.
 
 func TestSendOutOfHoursReminderMessage_RendersReviewerAsMention(t *testing.T) {
 	originalToken := os.Getenv("SLACK_BOT_TOKEN")
@@ -21,16 +19,10 @@ func TestSendOutOfHoursReminderMessage_RendersReviewerAsMention(t *testing.T) {
 
 	defer gock.Off()
 
-	// The mock only matches when the posted body contains the proper mention
-	// markup. If the bot posts the bare "@U05JSSXA6RL" literal, the request
-	// fails to match and SendOutOfHoursReminderMessage returns an error.
+	// json.Marshal escapes "<@U…>" to "<@U…>" in the body.
 	gock.New("https://slack.com").
 		Post("/api/chat.postMessage").
-		// json.Marshal HTML-escapes "<" / ">" to < / >, so the
-		// proper mention "<@U05JSSXA6RL>" appears in the body as
-		// "<@U05JSSXA6RL>". The leading < is what distinguishes
-		// a real mention from the broken bare "@U05JSSXA6RL" literal.
-		BodyString(`\\u003c@U05JSSXA6RL\\u003e`).
+		BodyString(`\\u003c@UREVIEWER\\u003e`).
 		Reply(200).
 		JSON(map[string]interface{}{"ok": true})
 
@@ -38,13 +30,13 @@ func TestSendOutOfHoursReminderMessage_RendersReviewerAsMention(t *testing.T) {
 		ID:           "task-mention",
 		SlackTS:      "1234.5678",
 		SlackChannel: "C12345",
-		Reviewer:     "U05JSSXA6RL",
+		Reviewer:     "UREVIEWER",
 		Status:       "in_review",
 	}
 
 	err := SendOutOfHoursReminderMessage(nil, task)
 	assert.NoError(t, err)
-	assert.True(t, gock.IsDone(), "expected a chat.postMessage containing <@U05JSSXA6RL>")
+	assert.True(t, gock.IsDone(), "expected a chat.postMessage containing <@UREVIEWER>")
 }
 
 func TestPostBusinessHoursNotificationToThread_RendersReviewerAsMention(t *testing.T) {
@@ -54,13 +46,10 @@ func TestPostBusinessHoursNotificationToThread_RendersReviewerAsMention(t *testi
 
 	defer gock.Off()
 
+	// json.Marshal escapes "<@U…>" to "<@U…>" in the body.
 	gock.New("https://slack.com").
 		Post("/api/chat.postMessage").
-		// json.Marshal HTML-escapes "<" / ">" to < / >, so the
-		// proper mention "<@U05JSSXA6RL>" appears in the body as
-		// "<@U05JSSXA6RL>". The leading < is what distinguishes
-		// a real mention from the broken bare "@U05JSSXA6RL" literal.
-		BodyString(`\\u003c@U05JSSXA6RL\\u003e`).
+		BodyString(`\\u003c@UREVIEWER\\u003e`).
 		Reply(200).
 		JSON(map[string]interface{}{"ok": true})
 
@@ -68,11 +57,11 @@ func TestPostBusinessHoursNotificationToThread_RendersReviewerAsMention(t *testi
 		ID:           "task-morning",
 		SlackTS:      "1234.5678",
 		SlackChannel: "C12345",
-		Reviewer:     "U05JSSXA6RL",
+		Reviewer:     "UREVIEWER",
 		Status:       "in_review",
 	}
 
 	err := PostBusinessHoursNotificationToThread(task, "UDEFAULT")
 	assert.NoError(t, err)
-	assert.True(t, gock.IsDone(), "expected a chat.postMessage containing <@U05JSSXA6RL>")
+	assert.True(t, gock.IsDone(), "expected a chat.postMessage containing <@UREVIEWER>")
 }

--- a/services/slack.go
+++ b/services/slack.go
@@ -454,7 +454,7 @@ func PostBusinessHoursNotificationToThread(task models.ReviewTask, mentionID str
 	// Append reviewer info if a reviewer is assigned
 	var reviewerText string
 	if task.Reviewer != "" {
-		reviewerText = t("notify.reviewer_in_morning", task.Reviewer)
+		reviewerText = t("notify.reviewer_in_morning", formatReviewerMentions(task.Reviewer))
 	}
 
 	message := t("notify.business_hours_morning", mentionText, reviewerText)
@@ -1053,7 +1053,7 @@ func GetNextBusinessDayMorningWithConfig(now time.Time, config *models.ChannelCo
 // SendOutOfHoursReminderMessage sends a reminder message for off-hours
 func SendOutOfHoursReminderMessage(db *gorm.DB, task models.ReviewTask) error {
 	t := i18n.L(task.Language)
-	message := t("notify.out_of_hours_reminder", task.Reviewer)
+	message := t("notify.out_of_hours_reminder", formatReviewerMentions(task.Reviewer))
 
 	pauseSelect := CreateStopOnlyPauseReminderSelect(task.ID, "pause_reminder", t("button.stop_reminder"), task.Language)
 	blocks := CreateMessageWithActionBlocks(message, pauseSelect)

--- a/services/tasks.go
+++ b/services/tasks.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -42,48 +43,59 @@ func CheckBusinessHoursTasks(db *gorm.DB) {
 			continue // Outside business hours, skip processing
 		}
 
-		// Randomly select reviewers (excluding PR author)
-		excludeIDs := []string{}
-		if task.PRAuthorSlackID != "" {
-			excludeIDs = append(excludeIDs, task.PRAuthorSlackID)
-		}
-		requiredApprovals := config.RequiredApprovals
-		if requiredApprovals <= 0 {
-			requiredApprovals = 1
-		}
-		reviewerIDs := SelectRandomReviewers(db, task.SlackChannel, labelName, requiredApprovals, excludeIDs)
-		reviewerID := ""
-		if len(reviewerIDs) > 0 {
-			reviewerID = reviewerIDs[0]
-		}
-		reviewersStr := strings.Join(reviewerIDs, ",")
-
-		// Send business hours notification to thread
-		if err := PostBusinessHoursNotificationToThread(task, config.DefaultMentionID); err != nil {
-			log.Printf("business hours notification error (task: %s): %v", task.ID, err)
+		if err := activateBusinessHoursTask(db, task, config, labelName); err != nil {
+			log.Printf("activate waiting_business_hours task failed (task: %s): %v", task.ID, err)
 			continue
-		}
-
-		// Update task status
-		task.Status = "in_review"
-		task.Reviewer = reviewerID
-		task.Reviewers = reviewersStr
-		task.UpdatedAt = time.Now()
-
-		if err := db.Save(&task).Error; err != nil {
-			log.Printf("task status update error (task: %s): %v", task.ID, err)
-			continue
-		}
-
-		log.Printf("waiting_business_hours task activated: %s", task.ID)
-
-		// If a reviewer was assigned, also send notification with change button
-		if reviewerID != "" {
-			if err := PostReviewerAssignedMessageWithChangeButton(task); err != nil {
-				log.Printf("reviewer assigned notification error: %v", err)
-			}
 		}
 	}
+}
+
+// activateBusinessHoursTask assigns reviewers to a task that was waiting for business
+// hours, posts the morning notification to the thread, and marks the task as in_review.
+// Reviewers are assigned to the task before the notification is sent so the morning
+// greeting can mention them. The task is persisted as in_review only after the
+// notification succeeds, so a failed notification leaves it to be retried next tick.
+func activateBusinessHoursTask(db *gorm.DB, task models.ReviewTask, config models.ChannelConfig, labelName string) error {
+	// Randomly select reviewers (excluding PR author)
+	excludeIDs := []string{}
+	if task.PRAuthorSlackID != "" {
+		excludeIDs = append(excludeIDs, task.PRAuthorSlackID)
+	}
+	requiredApprovals := config.RequiredApprovals
+	if requiredApprovals <= 0 {
+		requiredApprovals = 1
+	}
+	reviewerIDs := SelectRandomReviewers(db, task.SlackChannel, labelName, requiredApprovals, excludeIDs)
+	reviewerID := ""
+	if len(reviewerIDs) > 0 {
+		reviewerID = reviewerIDs[0]
+	}
+
+	// Assign reviewers before notifying so the morning greeting mentions them
+	task.Reviewer = reviewerID
+	task.Reviewers = strings.Join(reviewerIDs, ",")
+
+	// Send business hours notification to thread (mentions the assigned reviewers)
+	if err := PostBusinessHoursNotificationToThread(task, config.DefaultMentionID); err != nil {
+		return fmt.Errorf("business hours notification error: %w", err)
+	}
+
+	// Mark the task as in_review only after the notification succeeded
+	task.Status = "in_review"
+	task.UpdatedAt = time.Now()
+	if err := db.Save(&task).Error; err != nil {
+		return fmt.Errorf("task status update error: %w", err)
+	}
+
+	log.Printf("waiting_business_hours task activated: %s", task.ID)
+
+	// If a reviewer was assigned, also send notification with change button
+	if reviewerID != "" {
+		if err := PostReviewerAssignedMessageWithChangeButton(task); err != nil {
+			log.Printf("reviewer assigned notification error: %v", err)
+		}
+	}
+	return nil
 }
 
 // CheckPendingReReviewNotifications sends deferred re-review notifications when business hours begin


### PR DESCRIPTION
## 概要

レビュワーへのメンションが Slack 上で素のテキスト（`@U…`）として表示され、クリック可能なメンションにならず通知が機能していなかった不具合を修正します。

報告された症状（メンションが効かず素のテキストになる）:

```
@<ユーザーID> レビューしてくれたら嬉しいです...👀
```

## 原因

直近の変更で reviewer の値が解決済み Slack ユーザーID（`U…` / `W…`）に統一されました。しかし以下2つの i18n テンプレートが `@%s` をハードコードしており、そこに生のユーザーIDを渡していたため、Slack が `@U…` を素のテキストとして表示していました。Slack でメンションとして描画されるには `<@U…>` 形式が必要です。

- `notify.out_of_hours_reminder`（営業時間外リマインド）
- `notify.reviewer_in_morning`（朝の営業開始通知のレビュワー表示）

通常のリマインド (`notify.reminder`) など他の通知は既に `<@%s>` 形式で正しく描画されており、この2つだけ取り残されていました。

## 修正内容

- テンプレートの `@%s` を `%s` に変更（ja / en 両方）
- 呼び出し側で既存の `formatReviewerMentions` を通し、`<@U…>` 形式に整形
  - `SendOutOfHoursReminderMessage`
  - `PostBusinessHoursNotificationToThread`

これで他の通知と挙動が揃います。`formatReviewerMentions` は空文字や `@` 付きの値も安全に処理します。

## テスト

`services/reviewer_mention_render_test.go` を追加（TDD で先に失敗を確認 → 修正で green）。
gock で実際に Slack へ POST される body を検査し、reviewer が `<@U…>` 形式で送られることを保証します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
