### PR TITLE
実ネットワーク依存で flaky だったテストを gock スタブ化

### DIFF
--- a/handlers/slack_test.go
+++ b/handlers/slack_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"slack-review-notify/models"
 	"slack-review-notify/services"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -240,6 +242,20 @@ func TestHandleSlackAction_PauseReminder_Hours(t *testing.T) {
 func TestHandleSlackAction_PauseReminderInitial(t *testing.T) {
 	// Enable test mode (skip signature verification)
 	services.IsTestMode = true
+
+	// Stub the Slack API: the pause confirmation message (SendReminderPausedMessage)
+	// posts to chat.postMessage and does not honor test mode, so without this stub
+	// the test depends on real network reachability and flakes on a dial timeout.
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() { _ = os.Setenv("SLACK_BOT_TOKEN", originalToken) }()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
 
 	// Create test DB
 	db := setupTestDB(t)

--- a/services/out_of_hours_reminder_test.go
+++ b/services/out_of_hours_reminder_test.go
@@ -1,10 +1,12 @@
 package services
 
 import (
+	"os"
 	"slack-review-notify/models"
 	"testing"
 	"time"
 
+	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -57,6 +59,27 @@ func TestCheckInReviewTasks_OutOfHoursReminder(t *testing.T) {
 		UpdatedAt:    oldTime,
 	}
 	db.Create(&task)
+
+	// Stub the Slack API so the reminder send does not depend on real network
+	// reachability. Both the in-hours and out-of-hours reminder paths post to
+	// chat.postMessage; without this the test flakes (or hangs on a dial timeout)
+	// when the CI runner cannot reach slack.com.
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() { _ = os.Setenv("SLACK_BOT_TOKEN", originalToken) }()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+	// The in-hours reminder path also checks whether the channel is archived.
+	gock.New("https://slack.com").
+		Get("/api/conversations.info").
+		Persist().
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true, "channel": map[string]interface{}{"is_archived": false}})
 
 	// Execute CheckInReviewTasks
 	CheckInReviewTasks(db)


### PR DESCRIPTION
## 背景

PR #105 マージ後の `main` で Go CI の Test ジョブが落ちた（[該当 run](https://github.com/haruotsu/slack-review-notify/actions/runs/26858775171)）。実行時間が通常の約50秒から5分22秒に伸び、`dial tcp ... i/o timeout` が多発していた。

## 原因

落ちていたのは以下の2テストで、どちらも **gock でモックせず実際に `slack.com` へ HTTP POST していた**:

- `services.TestCheckInReviewTasks_OutOfHoursReminder`
- `handlers.TestHandleSlackAction_PauseReminderInitial`

リマインダー送信 (`SendOutOfHoursReminderMessage` / `SendReminderMessageWithDB`) とポーズ確認送信 (`SendReminderPausedMessage`) は `IsTestMode` を尊重せず実 HTTP を行い、**トランスポートエラー時のみ** error を返す。通常 CI では `slack.com` が即座に 401 を返すため成功扱いになり通っていたが、ランナーから `slack.com` に到達できないと 30〜60 秒の dial タイムアウト → アサーション失敗、という**ネットワーク依存の flaky テスト**だった。PR #105 のコード変更とは無関係。

## 対応

2テストに `gock` スタブ（`chat.postMessage` / `conversations.info`）を追加し、実ネットワークに依存せず決定論的に通るようにした。

- プロダクトコードは変更していない（テストのみ）
- `IsTestMode` への送信関数の短絡追加は見送った。`pending_rereview_test.go` が `IsTestMode=true` をリセットせず後続の gock ベーステストに漏らしているため、送信関数を短絡させると既存の gock テスト（`reviewer_mention_render_test.go` 等）が壊れるリスクがあるため。隔離された gock スタブが安全。

## 検証

- `go build ./...` ✅
- `go test ./...` 全パス ✅（対象2テストを `-count=3` でも安定）
- `make lint`（golangci-lint）クリーン ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)