### PR TITLE
朝の営業時間通知のレビュワー二重表示を1メッセージに統合

### DIFF
--- a/services/business_hours_activation_test.go
+++ b/services/business_hours_activation_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 // When a task waiting for business hours is activated, the reviewer is selected at
-// activation time. The morning greeting must mention that freshly-selected reviewer,
-// which only works if the reviewer is assigned to the task before the notification is
-// sent. This guards against the notification being posted before the assignment.
-func TestActivateBusinessHoursTask_MorningGreetingMentionsAssignedReviewer(t *testing.T) {
+// activation time and announced in a single morning message. Previously the reviewer
+// was announced twice: once in the morning greeting and again in a follow-up
+// "auto-assigned" message. The two are now merged, so activation must send exactly one
+// chat.postMessage that mentions the reviewer and carries the change/pause controls.
+func TestActivateBusinessHoursTask_SendsSingleMergedReviewerMessage(t *testing.T) {
 	originalToken := os.Getenv("SLACK_BOT_TOKEN")
 	defer func() { _ = os.Setenv("SLACK_BOT_TOKEN", originalToken) }()
 	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
@@ -50,28 +51,59 @@ func TestActivateBusinessHoursTask_MorningGreetingMentionsAssignedReviewer(t *te
 	}
 	db.Create(&task)
 
-	defer gock.Off()
+	defer gock.OffAll()
+	gock.CleanUnmatchedRequest()
 
-	// The morning greeting ("おはよう") must contain the assigned reviewer mention.
+	// The single morning message must mention the reviewer and carry the change
+	// reviewer button and the reminder pause select.
 	// json.Marshal escapes "<@UREV1>" to "<@UREV1>" in the body.
 	gock.New("https://slack.com").
 		Post("/api/chat.postMessage").
-		BodyString(`おはよう[\s\S]*\\u003c@UREV1\\u003e`).
-		Reply(200).
-		JSON(map[string]interface{}{"ok": true})
-
-	// The follow-up "reviewer assigned + change button" message.
-	gock.New("https://slack.com").
-		Post("/api/chat.postMessage").
+		BodyString(`おはよう[\s\S]*\\u003c@UREV1\\u003e[\s\S]*change_reviewer[\s\S]*pause_reminder_initial`).
 		Reply(200).
 		JSON(map[string]interface{}{"ok": true})
 
 	err := activateBusinessHoursTask(db, task, config, "needs-review")
 	assert.NoError(t, err)
-	assert.True(t, gock.IsDone(), "expected the morning greeting to mention <@UREV1>")
+	assert.True(t, gock.IsDone(), "expected one merged morning message with reviewer mention and controls")
+	assert.False(t, gock.HasUnmatchedRequest(), "expected no second reviewer-assigned message")
 
 	var updated models.ReviewTask
 	db.First(&updated, "id = ?", "task-activation")
 	assert.Equal(t, "in_review", updated.Status)
 	assert.Equal(t, "UREV1", updated.Reviewer)
+}
+
+// The merged morning message mentions every assigned reviewer (not just the first) and
+// includes the change reviewer button and the reminder pause select.
+func TestPostBusinessHoursNotificationToThread_MentionsAllReviewersWithControls(t *testing.T) {
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() { _ = os.Setenv("SLACK_BOT_TOKEN", originalToken) }()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.OffAll()
+	gock.CleanUnmatchedRequest()
+
+	// Reviewers are serialized in list order, so the mentions and controls appear in a
+	// deterministic sequence in the request body.
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		BodyString(`\\u003c@UREV1\\u003e \\u003c@UREV2\\u003e[\s\S]*change_reviewer[\s\S]*pause_reminder_initial`).
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	task := models.ReviewTask{
+		ID:           "task-morning-multi",
+		SlackTS:      "1234.5678",
+		SlackChannel: "C12345",
+		Reviewer:     "UREV1",
+		Reviewers:    "UREV1,UREV2",
+		Status:       "in_review",
+		Language:     "ja",
+	}
+
+	err := PostBusinessHoursNotificationToThread(task, "UDEFAULT")
+	assert.NoError(t, err)
+	assert.True(t, gock.IsDone(), "expected a single message mentioning all reviewers with controls")
+	assert.False(t, gock.HasUnmatchedRequest())
 }

--- a/services/slack.go
+++ b/services/slack.go
@@ -451,15 +451,25 @@ func PostBusinessHoursNotificationToThread(task models.ReviewTask, mentionID str
 	t := i18n.L(task.Language)
 	mentionText := buildMentionText(mentionID)
 
-	// Append reviewer info if a reviewer is assigned
+	// Mention every assigned reviewer in the morning greeting. The reviewer assignment
+	// and its change/pause controls are merged into this single message so reviewers
+	// are not announced twice in the thread.
+	reviewerMentions := formatReviewerCSVMentions(task.Reviewers, task.Reviewer)
 	var reviewerText string
-	if task.Reviewer != "" {
-		reviewerText = t("notify.reviewer_in_morning", formatReviewerMentions(task.Reviewer))
+	if reviewerMentions != "" {
+		reviewerText = t("notify.reviewer_in_morning", reviewerMentions)
 	}
 
 	message := t("notify.business_hours_morning", mentionText, reviewerText)
 
-	blocks := CreateMessageBlocks(message)
+	var blocks []map[string]interface{}
+	if reviewerMentions != "" {
+		changeButton := CreateChangeReviewerButton(task.ID, task.Language)
+		pauseSelect := CreateAllOptionsPauseReminderSelect(task.ID, "pause_reminder_initial", t("button.stop_reminder"), task.Language)
+		blocks = CreateMessageWithActionsBlocks(message, changeButton, pauseSelect)
+	} else {
+		blocks = CreateMessageBlocks(message)
+	}
 
 	body := map[string]interface{}{
 		"channel":   task.SlackChannel,
@@ -905,18 +915,7 @@ func IsChannelArchived(channelID string) (bool, error) {
 // PostReviewerAssignedMessageWithChangeButton displays the auto-assigned reviewers and shows a change button
 func PostReviewerAssignedMessageWithChangeButton(task models.ReviewTask) error {
 	t := i18n.L(task.Language)
-	var message string
-	if task.Reviewers != "" {
-		var mentions []string
-		for _, id := range strings.Split(task.Reviewers, ",") {
-			if trimmed := strings.TrimSpace(id); trimmed != "" {
-				mentions = append(mentions, fmt.Sprintf("<@%s>", trimmed))
-			}
-		}
-		message = t("notify.reviewer_auto_assigned", strings.Join(mentions, " "))
-	} else {
-		message = t("notify.reviewer_auto_assigned", fmt.Sprintf("<@%s>", task.Reviewer))
-	}
+	message := t("notify.reviewer_auto_assigned", formatReviewerCSVMentions(task.Reviewers, task.Reviewer))
 
 	changeButton := CreateChangeReviewerButton(task.ID, task.Language)
 	pauseSelect := CreateAllOptionsPauseReminderSelect(task.ID, "pause_reminder_initial", t("button.stop_reminder"), task.Language)
@@ -947,6 +946,21 @@ func PostReviewerAssignedMessageWithChangeButton(task models.ReviewTask) error {
 	}()
 
 	return nil
+}
+
+// formatReviewerCSVMentions builds Slack mentions from a comma-separated reviewer list,
+// falling back to a single reviewer ID when the list is empty.
+func formatReviewerCSVMentions(reviewersCSV, fallbackReviewer string) string {
+	var mentions []string
+	for _, id := range strings.Split(reviewersCSV, ",") {
+		if trimmed := strings.TrimSpace(id); trimmed != "" {
+			mentions = append(mentions, fmt.Sprintf("<@%s>", trimmed))
+		}
+	}
+	if len(mentions) == 0 && fallbackReviewer != "" {
+		mentions = append(mentions, fmt.Sprintf("<@%s>", fallbackReviewer))
+	}
+	return strings.Join(mentions, " ")
 }
 
 // formatReviewerMentions converts multiple reviewer IDs into Slack mention format

--- a/services/tasks.go
+++ b/services/tasks.go
@@ -71,7 +71,9 @@ func activateBusinessHoursTask(db *gorm.DB, task models.ReviewTask, config model
 		reviewerID = reviewerIDs[0]
 	}
 
-	// Assign reviewers before notifying so the morning greeting mentions them
+	// Assign reviewers before notifying so the morning greeting mentions them. The
+	// morning notification itself announces the reviewers and carries the change/pause
+	// controls, so no separate auto-assigned message is sent.
 	task.Reviewer = reviewerID
 	task.Reviewers = strings.Join(reviewerIDs, ",")
 
@@ -89,12 +91,6 @@ func activateBusinessHoursTask(db *gorm.DB, task models.ReviewTask, config model
 
 	log.Printf("waiting_business_hours task activated: %s", task.ID)
 
-	// If a reviewer was assigned, also send notification with change button
-	if reviewerID != "" {
-		if err := PostReviewerAssignedMessageWithChangeButton(task); err != nil {
-			log.Printf("reviewer assigned notification error: %v", err)
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
## 概要

朝の営業時間通知（`waiting_business_hours` タスクの有効化時）で、レビュワーへの言及が **2つのメッセージに重複して表示される** 不具合を修正します。

スレッドに以下の2つが投稿され、どちらもレビュワーに言及していました:

1. 朝の挨拶メッセージ（`PostBusinessHoursNotificationToThread`）
   - レビュワー言及あり（先頭1人のみ・ボタンなし）
2. 自動割り当てメッセージ（`PostReviewerAssignedMessageWithChangeButton`）
   - レビュワー言及あり（割り当て全員・「変わってほしい！」ボタン等あり）

これは直近のコミット `87016fb`（朝の挨拶でレビュワー割当を通知前に行う修正）で①にレビュワー行が追加された結果、②と二重になったものです。

## 変更内容

①と②を **1つのメッセージに統合** しました。

- `PostBusinessHoursNotificationToThread`: 朝の挨拶に **全レビュワーのメンション** ＋「変わってほしい！」ボタン ＋ リマインダ停止セレクトを載せる
  - 従来は先頭1人だけだったレビュワー行を、割当全員をメンションするよう修正
- `activateBusinessHoursTask`: 別投稿の `PostReviewerAssignedMessageWithChangeButton` 呼び出しを廃止
- メンション組み立てを `formatReviewerCSVMentions` ヘルパーに共通化（`PostReviewerAssignedMessageWithChangeButton` も同ヘルパーを使用。こちらは webhook の即時フローで引き続き利用）

即時フロー（営業時間中にPRがラベル付けされた場合）は元々レビュワー言及が②の1回だけなので、表示への影響はありません。

## テスト（TDDで追加）

- `activateBusinessHoursTask` が `chat.postMessage` を **1回だけ** 送ること（未マッチリクエストが無いことを検証し、2通目が送られないことを担保）
- 統合メッセージに割り当てレビュワー全員のメンション ＋ change_reviewer ボタン ＋ pause_reminder_initial セレクトが含まれること
- 既存の「レビュワー1人でもメンションされる」回帰テストを維持

`go test ./...` 全パス、`make lint` クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
