### PR TITLE
fix: unset-away で旧フォーマットの slack_user_id を削除できない不具合を修正

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	"slack-review-notify/services"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
@@ -677,4 +679,111 @@ func TestE2E_MultipleAwayPeriods_ExcludedFromReviewerAssignment(t *testing.T) {
 	var task models.ReviewTask
 	err := db.Where("pr_number = ? AND slack_channel = ?", 101, "C_E2E_BH").First(&task).Error
 	assert.NoError(t, err, "Review task should be created")
+}
+
+// sendSlashCommand posts a /slack-review-notify slash command to the test server
+// and returns the response body.
+func sendSlashCommand(t *testing.T, ts *httptest.Server, channelID, text string) string {
+	t.Helper()
+	form := url.Values{}
+	form.Set("command", "/slack-review-notify")
+	form.Set("text", text)
+	form.Set("channel_id", channelID)
+	form.Set("user_id", "U_E2E_ADMIN")
+	req, err := http.NewRequest("POST", ts.URL+"/slack/command", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return string(body)
+}
+
+// setupE2EAppWithCommands returns a test server that includes the slash command handler.
+func setupE2EAppWithCommands(t *testing.T) (*gorm.DB, *httptest.Server) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ReviewTask{}, &models.ChannelConfig{}, &models.UserMapping{}, &models.ReviewerAvailability{}))
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.POST("/webhook", handlers.HandleGitHubWebhook(db))
+	r.POST("/slack/actions", handlers.HandleSlackAction(db))
+	r.POST("/slack/command", handlers.HandleSlackCommand(db))
+
+	ts := httptest.NewServer(r)
+	return db, ts
+}
+
+// TestE2E_UnsetAway_LegacyUserID verifies that a ReviewerAvailability record
+// stored with the legacy "ID|displayname" slack_user_id format (written by an
+// older cleanUserID) can be fully removed via the unset-away slash command.
+// This exercises the LIKE fallback added to unsetAway in PR #108.
+func TestE2E_UnsetAway_LegacyUserID(t *testing.T) {
+	services.IsTestMode = true
+	defer func() { services.IsTestMode = false }()
+
+	db, ts := setupE2EAppWithCommands(t)
+	defer ts.Close()
+
+	// Insert a legacy record with "ID|displayname" format directly into the DB,
+	// simulating a record created before cleanUserID stripped the pipe suffix.
+	legacy := models.ReviewerAvailability{
+		ID:          uuid.NewString(),
+		SlackUserID: "ULEGACY|username",
+		Reason:      "on leave",
+	}
+	require.NoError(t, db.Create(&legacy).Error)
+
+	// Verify the record exists before the command.
+	var before int64
+	db.Model(&models.ReviewerAvailability{}).Where("slack_user_id = ?", "ULEGACY|username").Count(&before)
+	require.Equal(t, int64(1), before, "legacy record must exist before unset-away")
+
+	// Run unset-away with the clean ID (what cleanUserID returns from <@ULEGACY|username>).
+	body := sendSlashCommand(t, ts, "C_E2E_LEGACY", "unset-away <@ULEGACY|username>")
+	assert.Contains(t, body, "解除", "unset-away should report success (contains 解除)")
+
+	// The legacy record must now be gone (hard-deleted via LIKE fallback).
+	var after int64
+	db.Unscoped().Model(&models.ReviewerAvailability{}).
+		Where("slack_user_id = ? OR slack_user_id LIKE ?", "ULEGACY|username", "ULEGACY|%").
+		Count(&after)
+	assert.Equal(t, int64(0), after, "legacy record must be fully removed after unset-away")
+}
+
+// TestE2E_MigrateNormalizeSlackUserIDs verifies the full path: the startup
+// migration normalizes a legacy "ID|displayname" record, and afterwards the
+// record is reachable through the real slash-command path by its bare id —
+// proving normalization makes set-away/unset-away's exact-match work end to end.
+func TestE2E_MigrateNormalizeSlackUserIDs(t *testing.T) {
+	services.IsTestMode = true
+	defer func() { services.IsTestMode = false }()
+
+	db, ts := setupE2EAppWithCommands(t)
+	defer ts.Close()
+
+	// Seed a legacy record (pipe suffix) directly, as an old binary would have.
+	legacy := models.ReviewerAvailability{ID: uuid.NewString(), SlackUserID: "UMIG|testuser"}
+	require.NoError(t, db.Create(&legacy).Error)
+
+	// Run the migration (same call as main.go on startup).
+	require.NoError(t, models.MigrateNormalizeSlackUserIDs(db))
+
+	// The legacy record is now stored under the bare id.
+	var gotLegacy models.ReviewerAvailability
+	require.NoError(t, db.First(&gotLegacy, "id = ?", legacy.ID).Error)
+	assert.Equal(t, "UMIG", gotLegacy.SlackUserID, "pipe suffix must be stripped by the migration")
+
+	// End-to-end: unset-away with the bare id now matches via the EXACT path
+	// (no LIKE fallback needed), proving the migration repaired the record so
+	// the normal slash-command flow finds it.
+	body := sendSlashCommand(t, ts, "C_E2E_MIG", "unset-away <@UMIG>")
+	assert.Contains(t, body, "解除", "unset-away should remove the normalized record")
+
+	var count int64
+	db.Unscoped().Model(&models.ReviewerAvailability{}).Where("slack_user_id = ?", "UMIG").Count(&count)
+	assert.Equal(t, int64(0), count, "normalized record must be removed via the slash-command path")
 }

--- a/handlers/away_modal.go
+++ b/handlers/away_modal.go
@@ -112,7 +112,7 @@ func handleAwayModalSubmission(c *gin.Context, db *gorm.DB, payload SlackActionP
 	// updates Reason only; a new period inserts a fresh row.
 	now := time.Now()
 	var existing models.ReviewerAvailability
-	query := applyPeriodMatch(db.Where("slack_user_id = ?", form.SlackUserID), form.AwayFrom, form.AwayUntil)
+	query := models.MatchPeriod(db.Where("slack_user_id = ?", form.SlackUserID), form.AwayFrom, form.AwayUntil)
 	err = query.First(&existing).Error
 	switch {
 	case err == nil:

--- a/handlers/command.go
+++ b/handlers/command.go
@@ -1439,7 +1439,20 @@ func unsetAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang s
 		return
 	}
 
+	// Always match the clean ID exactly. Additionally catch legacy records stored
+	// as "ID|displayname" (written by an older cleanUserID before the pipe-strip
+	// fix) via a LIKE prefix — but ONLY when slackUserID is a well-formed Slack
+	// id. A well-formed id ([UW][0-9A-Z]+) cannot contain LIKE metacharacters
+	// (% or _), so gating here prevents a caller-supplied "%"/"_" from widening
+	// this irreversible hard-delete to other users' legacy rows. Legacy pipe
+	// variants only ever exist for real Slack ids, so the gate loses no match.
 	query := db.Unscoped().Where("slack_user_id = ?", slackUserID)
+	if services.LooksLikeResolvedSlackUserID(slackUserID) {
+		query = db.Unscoped().Where(
+			"slack_user_id = ? OR slack_user_id LIKE ?",
+			slackUserID, slackUserID+"|%",
+		)
+	}
 
 	// If a date is specified, delete only the matching period; otherwise delete all.
 	if len(parts) > 1 {

--- a/handlers/command.go
+++ b/handlers/command.go
@@ -1310,22 +1310,6 @@ func parseAwayPeriod(parts []string, loc *time.Location, now time.Time, rejectPa
 	return p, ""
 }
 
-// applyPeriodMatch narrows a query to records whose away_from/away_until exactly match the period.
-// nil bounds match NULL columns, so an indefinite period matches only indefinite records.
-func applyPeriodMatch(q *gorm.DB, from, until *time.Time) *gorm.DB {
-	if from == nil {
-		q = q.Where("away_from IS NULL")
-	} else {
-		q = q.Where("away_from = ?", from)
-	}
-	if until == nil {
-		q = q.Where("away_until IS NULL")
-	} else {
-		q = q.Where("away_until = ?", until)
-	}
-	return q
-}
-
 // setAway marks a user as away/on leave
 func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang string) {
 	t := i18n.L(lang)
@@ -1366,7 +1350,7 @@ func setAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang str
 	// plus a sudden sick day), so each distinct period is stored as its own record.
 	// To stay idempotent, update the reason when an identical period already exists.
 	var existing models.ReviewerAvailability
-	matched := applyPeriodMatch(db.Where("slack_user_id = ?", slackUserID), awayFrom, awayUntil)
+	matched := models.MatchPeriod(db.Where("slack_user_id = ?", slackUserID), awayFrom, awayUntil)
 	err := matched.First(&existing).Error
 	switch {
 	case err == nil:
@@ -1467,7 +1451,7 @@ func unsetAway(c *gin.Context, db *gorm.DB, channelID, labelName, params, lang s
 		// Extra tokens without a date keyword (e.g. a stray "reason") must not
 		// silently restrict the match to indefinite records.
 		if period.from != nil || period.until != nil {
-			query = applyPeriodMatch(query, period.from, period.until)
+			query = models.MatchPeriod(query, period.from, period.until)
 		}
 	}
 

--- a/handlers/command_db_test.go
+++ b/handlers/command_db_test.go
@@ -695,6 +695,53 @@ func TestUnsetAway_WildcardDoesNotMatchLegacy(t *testing.T) {
 	assert.Equal(t, int64(1), count, "wildcard input must not delete another user's legacy row")
 }
 
+// TestUnsetAway_LegacyPipeFormat_SpecificPeriod guards the trickiest path: a
+// legacy "ID|displayname" record removed by unset-away WITH a date. The query
+// combines "(exact OR LIKE) AND period", so the period predicate must apply to
+// the LIKE branch too — only the matching period of the legacy row is removed,
+// and a non-matching legacy period for the same user survives.
+func TestUnsetAway_LegacyPipeFormat_SpecificPeriod(t *testing.T) {
+	db := setupCommandIntegrationTestDB(t)
+
+	services.IsTestMode = true
+	defer func() {
+		services.IsTestMode = false
+	}()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/slack/command", HandleSlackCommand(db))
+
+	send := func(text string) *httptest.ResponseRecorder {
+		req := setupHTTPRequest(t, text, "C12345")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// Seed two periods via set-away so the stored away_from/away_until exactly
+	// match what the parser produces, then rewrite the id to the legacy pipe
+	// format an older cleanUserID would have stored.
+	send("set-away <@UPIPEP> on 2099-06-01")
+	send("set-away <@UPIPEP> on 2099-06-10")
+	assert.NoError(t, db.Model(&models.ReviewerAvailability{}).
+		Where("slack_user_id = ?", "UPIPEP").
+		Update("slack_user_id", "UPIPEP|username").Error)
+
+	// Remove only the 2099-06-01 period of the legacy-format records.
+	w := send("unset-away <@UPIPEP|username> on 2099-06-01")
+	assert.Equal(t, 200, w.Code)
+	assert.Contains(t, w.Body.String(), "休暇を解除しました")
+
+	var records []models.ReviewerAvailability
+	db.Where("slack_user_id LIKE ?", "UPIPEP%").Find(&records)
+	assert.Len(t, records, 1, "only the matching legacy period should be removed")
+	if len(records) == 1 && assert.NotNil(t, records[0].AwayFrom) {
+		assert.Equal(t, "2099-06-10", records[0].AwayFrom.Format("2006-01-02"),
+			"the non-matching legacy period must remain")
+	}
+}
+
 func TestShowAvailability_Integration(t *testing.T) {
 	db := setupCommandIntegrationTestDB(t)
 

--- a/handlers/command_db_test.go
+++ b/handlers/command_db_test.go
@@ -621,6 +621,80 @@ func TestUnsetAway_Integration(t *testing.T) {
 	assert.Contains(t, w3.Body.String(), "休暇に設定されていません")
 }
 
+// TestUnsetAway_LegacyPipeFormat verifies that a record stored with the legacy
+// "ID|displayname" slack_user_id (written by an older cleanUserID before the
+// pipe-strip fix) is removed by unset-away via the LIKE fallback, exercised
+// through the slash-command handler rather than only the E2E layer.
+func TestUnsetAway_LegacyPipeFormat(t *testing.T) {
+	db := setupCommandIntegrationTestDB(t)
+
+	services.IsTestMode = true
+	defer func() {
+		services.IsTestMode = false
+	}()
+
+	// Seed a legacy-format record directly.
+	require := db.Create(&models.ReviewerAvailability{
+		ID:          "rec-legacy-pipe",
+		SlackUserID: "ULEGACY|username",
+		Reason:      "old",
+	})
+	assert.NoError(t, require.Error)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/slack/command", HandleSlackCommand(db))
+
+	// cleanUserID(<@ULEGACY|username>) -> "ULEGACY", a well-formed id, so the
+	// LIKE fallback applies and matches the legacy "ULEGACY|username" row.
+	req := setupHTTPRequest(t, "unset-away <@ULEGACY|username>", "C12345")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.Contains(t, w.Body.String(), "休暇を解除しました")
+
+	var count int64
+	db.Unscoped().Model(&models.ReviewerAvailability{}).
+		Where("slack_user_id LIKE ?", "ULEGACY%").Count(&count)
+	assert.Equal(t, int64(0), count, "legacy record must be fully removed")
+}
+
+// TestUnsetAway_WildcardDoesNotMatchLegacy guards the LIKE-escaping fix: a
+// caller-supplied LIKE metacharacter ("%") must NOT widen the delete to other
+// users' legacy rows. cleanUserID("U%") is not a well-formed Slack id, so the
+// LIKE fallback is skipped and only an exact match is attempted.
+func TestUnsetAway_WildcardDoesNotMatchLegacy(t *testing.T) {
+	db := setupCommandIntegrationTestDB(t)
+
+	services.IsTestMode = true
+	defer func() {
+		services.IsTestMode = false
+	}()
+
+	// A legacy row that a naive `LIKE 'U%|%'` would have matched.
+	res := db.Create(&models.ReviewerAvailability{
+		ID:          "rec-victim",
+		SlackUserID: "UVICTIM|username",
+		Reason:      "should survive",
+	})
+	assert.NoError(t, res.Error)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/slack/command", HandleSlackCommand(db))
+
+	// "U%" must not delete UVICTIM's legacy record.
+	req := setupHTTPRequest(t, "unset-away U%", "C12345")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+
+	var count int64
+	db.Unscoped().Model(&models.ReviewerAvailability{}).
+		Where("slack_user_id = ?", "UVICTIM|username").Count(&count)
+	assert.Equal(t, int64(1), count, "wildcard input must not delete another user's legacy row")
+}
+
 func TestShowAvailability_Integration(t *testing.T) {
 	db := setupCommandIntegrationTestDB(t)
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,12 @@ func main() {
 		log.Fatal("fail to migrate reviewer availability index:", err)
 	}
 
+	// Normalize legacy slack_user_id values stored as "ID|displayname" by
+	// an older version of cleanUserID that did not strip the pipe suffix.
+	if err := models.MigrateNormalizeSlackUserIDs(db); err != nil {
+		log.Fatal("fail to normalize slack_user_id values:", err)
+	}
+
 	// Surface user_mappings rows whose slack_user_id is not a resolved U-id.
 	// These date from before the modal picker landed and silently leak the PR
 	// author into the reviewer candidate pool. The operator can re-register

--- a/models/reviewer_availability.go
+++ b/models/reviewer_availability.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"log"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -57,4 +59,86 @@ func MigrateReviewerAvailabilityIndex(db *gorm.DB) error {
 		}
 	}
 	return nil
+}
+
+// MigrateNormalizeSlackUserIDs normalizes legacy slack_user_id values that
+// contain a pipe-separated display name (e.g. "UABC123|username"). These were
+// stored by an older version of cleanUserID that did not strip the
+// "|displayname" suffix from Slack's autocomplete-escape format
+// (<@UABC123|username>). After this migration every record stores only the
+// bare Slack user ID so that exact-match queries in set-away/unset-away work
+// correctly regardless of which code version created the record.
+//
+// The whole pass runs in a single transaction so a mid-loop failure cannot
+// leave the table half-normalized, matching MigrateReviewerAvailabilityIndex's
+// transactional style. Only rows containing a pipe are loaded, so once
+// normalization is complete a later startup scans zero rows instead of the
+// whole table.
+func MigrateNormalizeSlackUserIDs(db *gorm.DB) error {
+	if !db.Migrator().HasTable(&ReviewerAvailability{}) {
+		return nil
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		var records []ReviewerAvailability
+		if err := tx.Unscoped().Where("slack_user_id LIKE ?", "%|%").Find(&records).Error; err != nil {
+			return err
+		}
+
+		var normalized int
+		for _, r := range records {
+			idx := strings.Index(r.SlackUserID, "|")
+			// idx <= 0 would yield an empty id (a leading pipe is corrupt data
+			// that no real code path produces), so leave such rows untouched.
+			if idx <= 0 {
+				continue
+			}
+			cleanID := r.SlackUserID[:idx]
+
+			// Dedup: if an identical (clean id, same period) row already exists,
+			// normalizing this legacy row would create a duplicate (user, period)
+			// pair. Drop the legacy row instead so the "one row per (user, period)"
+			// invariant survives. NULL-aware so indefinite periods match correctly.
+			var dup int64
+			dupQuery := matchPeriod(
+				tx.Unscoped().Model(&ReviewerAvailability{}).Where("id <> ? AND slack_user_id = ?", r.ID, cleanID),
+				r.AwayFrom, r.AwayUntil,
+			)
+			if err := dupQuery.Count(&dup).Error; err != nil {
+				return err
+			}
+
+			if dup > 0 {
+				if err := tx.Unscoped().Delete(&ReviewerAvailability{}, "id = ?", r.ID).Error; err != nil {
+					return err
+				}
+			} else if err := tx.Unscoped().Model(&ReviewerAvailability{}).
+				Where("id = ?", r.ID).Update("slack_user_id", cleanID).Error; err != nil {
+				return err
+			}
+			normalized++
+		}
+
+		if normalized > 0 {
+			log.Printf("normalized %d legacy slack_user_id value(s)", normalized)
+		}
+		return nil
+	})
+}
+
+// matchPeriod narrows a query to rows whose away_from/away_until exactly match
+// the given bounds, treating nil as a NULL column (so an indefinite period
+// matches only indefinite rows).
+func matchPeriod(q *gorm.DB, from, until *time.Time) *gorm.DB {
+	if from == nil {
+		q = q.Where("away_from IS NULL")
+	} else {
+		q = q.Where("away_from = ?", from)
+	}
+	if until == nil {
+		q = q.Where("away_until IS NULL")
+	} else {
+		q = q.Where("away_until = ?", until)
+	}
+	return q
 }

--- a/models/reviewer_availability.go
+++ b/models/reviewer_availability.go
@@ -100,7 +100,7 @@ func MigrateNormalizeSlackUserIDs(db *gorm.DB) error {
 			// pair. Drop the legacy row instead so the "one row per (user, period)"
 			// invariant survives. NULL-aware so indefinite periods match correctly.
 			var dup int64
-			dupQuery := matchPeriod(
+			dupQuery := MatchPeriod(
 				tx.Unscoped().Model(&ReviewerAvailability{}).Where("id <> ? AND slack_user_id = ?", r.ID, cleanID),
 				r.AwayFrom, r.AwayUntil,
 			)
@@ -126,10 +126,11 @@ func MigrateNormalizeSlackUserIDs(db *gorm.DB) error {
 	})
 }
 
-// matchPeriod narrows a query to rows whose away_from/away_until exactly match
+// MatchPeriod narrows a query to rows whose away_from/away_until exactly match
 // the given bounds, treating nil as a NULL column (so an indefinite period
-// matches only indefinite rows).
-func matchPeriod(q *gorm.DB, from, until *time.Time) *gorm.DB {
+// matches only indefinite rows). Shared by the set-away/unset-away handlers and
+// the normalization migration so period matching stays consistent everywhere.
+func MatchPeriod(q *gorm.DB, from, until *time.Time) *gorm.DB {
 	if from == nil {
 		q = q.Where("away_from IS NULL")
 	} else {

--- a/models/reviewer_availability_test.go
+++ b/models/reviewer_availability_test.go
@@ -77,6 +77,159 @@ func TestMigrateReviewerAvailabilityIndex_LegacyDB(t *testing.T) {
 	}
 }
 
+// TestMigrateNormalizeSlackUserIDs verifies that legacy "ID|displayname" values
+// are stripped to the bare ID, and that records with clean IDs are untouched.
+func TestMigrateNormalizeSlackUserIDs(t *testing.T) {
+	dbPath := t.TempDir() + "/normalize.db"
+	db := openSilent(t, dbPath)
+	if err := db.AutoMigrate(&ReviewerAvailability{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	// Insert one legacy record and one already-clean record.
+	legacy := ReviewerAvailability{ID: uuid.NewString(), SlackUserID: "UABC123|username", Reason: "old"}
+	clean := ReviewerAvailability{ID: uuid.NewString(), SlackUserID: "UDEF456", Reason: "new"}
+	if err := db.Create(&legacy).Error; err != nil {
+		t.Fatalf("create legacy: %v", err)
+	}
+	if err := db.Create(&clean).Error; err != nil {
+		t.Fatalf("create clean: %v", err)
+	}
+
+	if err := MigrateNormalizeSlackUserIDs(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	var got ReviewerAvailability
+	if err := db.First(&got, "id = ?", legacy.ID).Error; err != nil {
+		t.Fatalf("fetch legacy: %v", err)
+	}
+	if got.SlackUserID != "UABC123" {
+		t.Errorf("legacy record: want SlackUserID %q, got %q", "UABC123", got.SlackUserID)
+	}
+
+	var gotClean ReviewerAvailability
+	if err := db.First(&gotClean, "id = ?", clean.ID).Error; err != nil {
+		t.Fatalf("fetch clean: %v", err)
+	}
+	if gotClean.SlackUserID != "UDEF456" {
+		t.Errorf("clean record should be unchanged: want %q, got %q", "UDEF456", gotClean.SlackUserID)
+	}
+}
+
+// TestMigrateNormalizeSlackUserIDs_Dedup verifies that when a user already has
+// a clean-ID record for the same period, normalizing the legacy "ID|name" row
+// drops it instead of creating a duplicate (user, period) pair.
+func TestMigrateNormalizeSlackUserIDs_Dedup(t *testing.T) {
+	dbPath := t.TempDir() + "/dedup.db"
+	db := openSilent(t, dbPath)
+	if err := db.AutoMigrate(&ReviewerAvailability{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	// Same user, same (indefinite) period: one legacy row and one clean row.
+	legacy := ReviewerAvailability{ID: uuid.NewString(), SlackUserID: "UDUP|username", Reason: "legacy"}
+	clean := ReviewerAvailability{ID: uuid.NewString(), SlackUserID: "UDUP", Reason: "clean"}
+	if err := db.Create(&legacy).Error; err != nil {
+		t.Fatalf("create legacy: %v", err)
+	}
+	if err := db.Create(&clean).Error; err != nil {
+		t.Fatalf("create clean: %v", err)
+	}
+
+	if err := MigrateNormalizeSlackUserIDs(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Exactly one row must remain for UDUP — the legacy row was deduped away,
+	// not normalized into a second identical (user, period) row.
+	var count int64
+	db.Model(&ReviewerAvailability{}).Where("slack_user_id = ?", "UDUP").Count(&count)
+	if count != 1 {
+		t.Fatalf("expected 1 row after dedup, got %d", count)
+	}
+	// The surviving row is the pre-existing clean one.
+	var got ReviewerAvailability
+	if err := db.First(&got, "slack_user_id = ?", "UDUP").Error; err != nil {
+		t.Fatalf("fetch survivor: %v", err)
+	}
+	if got.ID != clean.ID {
+		t.Errorf("dedup should keep the existing clean row %q, kept %q", clean.ID, got.ID)
+	}
+}
+
+// TestMigrateNormalizeSlackUserIDs_Idempotent confirms the normalization is a
+// no-op when re-run (it runs on every startup), matching the index migration's
+// idempotency guarantee.
+func TestMigrateNormalizeSlackUserIDs_Idempotent(t *testing.T) {
+	dbPath := t.TempDir() + "/normalize-idem.db"
+	db := openSilent(t, dbPath)
+	if err := db.AutoMigrate(&ReviewerAvailability{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	legacy := ReviewerAvailability{ID: uuid.NewString(), SlackUserID: "UIDEM|username"}
+	if err := db.Create(&legacy).Error; err != nil {
+		t.Fatalf("create legacy: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := MigrateNormalizeSlackUserIDs(db); err != nil {
+			t.Fatalf("migrate (run %d): %v", i, err)
+		}
+		var got ReviewerAvailability
+		if err := db.First(&got, "id = ?", legacy.ID).Error; err != nil {
+			t.Fatalf("fetch after run %d: %v", i, err)
+		}
+		if got.SlackUserID != "UIDEM" {
+			t.Errorf("run %d: want %q, got %q", i, "UIDEM", got.SlackUserID)
+		}
+	}
+}
+
+// TestMigrateNormalizeSlackUserIDs_MultipleAndMultiPipe verifies that every
+// legacy row in a single pass is normalized, and that a value with multiple
+// pipes is truncated at the first pipe.
+func TestMigrateNormalizeSlackUserIDs_MultipleAndMultiPipe(t *testing.T) {
+	dbPath := t.TempDir() + "/normalize-multi.db"
+	db := openSilent(t, dbPath)
+	if err := db.AutoMigrate(&ReviewerAvailability{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	rows := map[string]string{ // id -> legacy slack_user_id
+		uuid.NewString(): "UAAA|alice",
+		uuid.NewString(): "UBBB|bob",
+		uuid.NewString(): "UCCC|name|extra", // multiple pipes -> truncate at first
+	}
+	want := map[string]string{ // same id -> expected normalized id
+		"UAAA|alice":      "UAAA",
+		"UBBB|bob":        "UBBB",
+		"UCCC|name|extra": "UCCC",
+	}
+	ids := map[string]string{} // id -> original legacy value
+	for id, sid := range rows {
+		if err := db.Create(&ReviewerAvailability{ID: id, SlackUserID: sid}).Error; err != nil {
+			t.Fatalf("create %s: %v", sid, err)
+		}
+		ids[id] = sid
+	}
+
+	if err := MigrateNormalizeSlackUserIDs(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	for id, original := range ids {
+		var got ReviewerAvailability
+		if err := db.First(&got, "id = ?", id).Error; err != nil {
+			t.Fatalf("fetch %s: %v", id, err)
+		}
+		if got.SlackUserID != want[original] {
+			t.Errorf("%q: want %q, got %q", original, want[original], got.SlackUserID)
+		}
+	}
+}
+
 // TestMigrateReviewerAvailabilityIndex_Idempotent confirms the migration is a
 // no-op on a fresh DB (already non-unique) and safe to run repeatedly.
 func TestMigrateReviewerAvailabilityIndex_Idempotent(t *testing.T) {


### PR DESCRIPTION
## 問題

`cleanUserID` が `|displayname` サフィックスを除去するように修正される前に登録された set-away レコードは、`slack_user_id` が `UABC123|username` 形式で DB に保存されていた。

その後 `cleanUserID` が修正され `UABC123` のみを返すようになったため、`unset-away @user` を実行しても WHERE 句が旧レコードにマッチせず、1 件だけ残ってしまう現象が発生する。

## 根本原因

- 旧コード（修正前）: `UABC123|username` として保存
- 新コード（修正後）: `UABC123` として保存

`unset-away @user` は `cleanUserID` で `UABC123` を得るが、旧フォーマットレコード `UABC123|username` にはマッチしない。

## 修正内容

1. `MigrateNormalizeSlackUserIDs`（models/reviewer_availability.go）: 起動時に既存レコードの `ID|displayname` を `ID` に正規化するマイグレーションを追加。トランザクションで原子的に処理し、対象行のみをロードする。同一ユーザー・同一期間のクリーンなレコードが既存の場合は旧レコードを削除してデデュープする。正規化件数をログ出力する。
2. `unsetAway`（handlers/command.go）: `slack_user_id LIKE 'ID|%'` のフォールバック条件を追加し、マイグレーション適用前でも安全に削除できるよう二重防護。LIKE 特殊文字（`%`/`_`）による他ユーザーレコードの巻き込み削除を防ぐため、well-formed な Slack id（`LooksLikeResolvedSlackUserID`）のときのみ LIKE 経路を適用する。

## スコープ

今回の正規化対象は `ReviewerAvailability` テーブルのみ。同じ `cleanUserID` を経由する `UserMapping.slack_user_id` は既存の `LogLegacyUserMappings` が WARN ログを出して手動再登録を促す方針、`ChannelConfig.ReviewerList` 等は対象外（必要なら別途対応）。

## Test plan

- [x] `TestMigrateNormalizeSlackUserIDs` — 旧フォーマットの正規化・クリーンなレコードの不変を検証
- [x] `TestMigrateNormalizeSlackUserIDs_Dedup` — 同一ユーザー・同一期間の重複をデデュープすることを検証
- [x] `TestMigrateNormalizeSlackUserIDs_Idempotent` — 再実行が no-op であることを検証
- [x] `TestMigrateNormalizeSlackUserIDs_MultipleAndMultiPipe` — 複数レコード・複数パイプの正規化を検証
- [x] `TestUnsetAway_LegacyPipeFormat` — handler 層で旧フォーマットの削除を検証
- [x] `TestUnsetAway_WildcardDoesNotMatchLegacy` — ワイルドカード入力で他ユーザーのレコードを削除しないことを検証
- [x] 既存の `TestUnsetAway_*` テストがすべて通ることを確認
- [x] `go test ./...` 全 PASS
- [x] E2E（slackhog）: `TestE2E_UnsetAway_LegacyUserID` / `TestE2E_MigrateNormalizeSlackUserIDs` を追加し PASS
