### PR TITLE
fix: 再レビュー依頼の sender と reviewer が同一なら通知しない

### DIFF
--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -528,6 +528,14 @@ func handleReviewRequestedEvent(c *gin.Context, db *gorm.DB, e *github.PullReque
 			log.Printf("task reactivated for re-review: id=%s, repo=%s, pr=%d", latestTask.ID, repoFullName, pr.GetNumber())
 		}
 
+		// sender と reviewer が同一表示の場合、「X さんが X に再レビューを依頼しました」という
+		// 無意味な通知になるため、状態復帰だけ行い通知（即時/遅延）はスキップする
+		if senderMention == reviewerMention {
+			log.Printf("skip re-review notification: sender and reviewer are the same (%s): task=%s",
+				senderMention, latestTask.ID)
+			continue
+		}
+
 		// Check business hours before sending re-review notification
 		var config models.ChannelConfig
 		labelName := latestTask.LabelName

--- a/handlers/webhook_test.go
+++ b/handlers/webhook_test.go
@@ -2144,3 +2144,60 @@ func TestHandleReviewRequestedEvent_WithinBusinessHours_SendsImmediately(t *test
 	assert.False(t, updatedTask.PendingReReviewNotify, "Notification should be sent immediately without business hours config")
 	assert.True(t, gock.IsDone(), "Slack notification should have been sent")
 }
+
+func TestHandleReviewRequestedEvent_SkipsWhenSenderEqualsReviewer(t *testing.T) {
+	db := setupTestDB(t)
+	gin.SetMode(gin.TestMode)
+	services.IsTestMode = true
+
+	// Register a Slack mock; if it stays unconsumed (gock.IsDone() == false),
+	// no re-review notification was posted.
+	defer gock.Off()
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	// Completed task: status revert must still happen even when the notification is skipped
+	task := models.ReviewTask{
+		ID:           "rereview-same-user-task",
+		PRURL:        "https://github.com/owner/repo/pull/600",
+		Repo:         "owner/repo",
+		PRNumber:     600,
+		Title:        "Test PR",
+		SlackTS:      "1234.6000",
+		SlackChannel: "C_NO_CONFIG",
+		Status:       "completed",
+		LabelName:    "needs-review",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	db.Create(&task)
+
+	// sender と requested_reviewer が同一ログイン → 同一メンションに解決される
+	payload := `{
+		"action": "review_requested",
+		"pull_request": {"number": 600, "html_url": "https://github.com/owner/repo/pull/600"},
+		"repository": {"full_name": "owner/repo", "owner": {"login": "owner"}, "name": "repo"},
+		"sender": {"login": "author"},
+		"requested_reviewer": {"login": "author"}
+	}`
+
+	req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "pull_request")
+
+	w := httptest.NewRecorder()
+	router := gin.Default()
+	router.POST("/webhook", HandleGitHubWebhook(db))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// 通知はスキップされるが、状態復帰は従来通り行われる
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "rereview-same-user-task").First(&updatedTask)
+	assert.Equal(t, "in_review", updatedTask.Status, "Completed task should still be reverted to in_review")
+	assert.False(t, updatedTask.PendingReReviewNotify, "Should not defer when sender equals reviewer")
+	assert.False(t, gock.IsDone(), "No re-review notification should be sent when sender equals reviewer")
+}

--- a/services/pending_rereview_test.go
+++ b/services/pending_rereview_test.go
@@ -278,6 +278,71 @@ func TestCheckPendingReReviewNotifications_MultipleNotifications(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Both Slack notifications should have been sent")
 }
 
+func TestCheckPendingReReviewNotifications_SkipsSamePair(t *testing.T) {
+	now := time.Now()
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	nowJST := now.In(loc)
+	if nowJST.Weekday() == time.Saturday || nowJST.Weekday() == time.Sunday {
+		t.Skip("This test requires running on a weekday")
+	}
+
+	db := setupTestDB(t)
+	IsTestMode = true
+
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() { _ = os.Setenv("SLACK_BOT_TOKEN", originalToken) }()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+	defer gock.Off()
+	// Register 2 mocks but expect only 1 to be consumed (the differing pair).
+	// The identical pair must be skipped, leaving one mock pending → gock.IsDone() == false.
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	config := models.ChannelConfig{
+		ID:                 "config-same-pair-rr",
+		SlackChannelID:     "C_SAME_PAIR_RR",
+		LabelName:          "needs-review",
+		IsActive:           true,
+		BusinessHoursStart: "00:00",
+		BusinessHoursEnd:   "23:59",
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}
+	db.Create(&config)
+
+	// First pair is identical (should be skipped), second pair differs (should be sent)
+	task := models.ReviewTask{
+		ID:                      "same-pair-rr-task",
+		PRURL:                   "https://github.com/owner/repo/pull/606",
+		Repo:                    "owner/repo",
+		PRNumber:                606,
+		Title:                   "Test PR",
+		SlackTS:                 "1234.2222",
+		SlackChannel:            "C_SAME_PAIR_RR",
+		Status:                  "in_review",
+		LabelName:               "needs-review",
+		PendingReReviewNotify:   true,
+		PendingReReviewSender:   "<@USAME>,<@USENDER>",
+		PendingReReviewReviewer: "<@USAME>,<@UREVIEWER>",
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+	}
+	db.Create(&task)
+
+	CheckPendingReReviewNotifications(db)
+
+	var updatedTask models.ReviewTask
+	db.Where("id = ?", "same-pair-rr-task").First(&updatedTask)
+	assert.False(t, updatedTask.PendingReReviewNotify, "Pending flag should be cleared")
+	assert.False(t, gock.IsDone(), "Identical sender/reviewer pair should be skipped, only one notification sent")
+}
+
 func TestClearPendingReReviewFlags_CASMiss(t *testing.T) {
 	db := setupTestDB(t)
 	IsTestMode = true

--- a/services/tasks.go
+++ b/services/tasks.go
@@ -132,6 +132,11 @@ func CheckPendingReReviewNotifications(db *gorm.DB) {
 		reviewers := strings.Split(task.PendingReReviewReviewer, ",")
 		t := i18n.L(task.Language)
 		for idx := 0; idx < len(senders) && idx < len(reviewers); idx++ {
+			// sender と reviewer が同一表示のペアは無意味な通知になるためスキップ
+			// （本変更前に蓄積された pending データへの防御）
+			if senders[idx] == reviewers[idx] {
+				continue
+			}
 			message := t("notify.re_review_requested", senders[idx], reviewers[idx])
 			if err := PostToThread(task.SlackChannel, task.SlackTS, message); err != nil {
 				log.Printf("deferred re-review notification error (task: %s, idx: %d): %v", task.ID, idx, err)


### PR DESCRIPTION
## 概要

GitHub の `review_requested`（Re-request review）を検知して送る再レビュー通知 `notify.re_review_requested`（`🔄 %s さんが %s に再レビューを依頼しました。対応をお願いします！`）について、**依頼した人（sender）と依頼された人（reviewer）が同一表示になる場合に通知をスキップ**するようにしました。

これまではこのケースで「X さんが X に再レビューを依頼しました」という無意味な通知が送られていました。

## 変更内容

- `handlers/webhook.go`: `handleReviewRequestedEvent` で sender と reviewer のメンションが同一の場合、即時送信・営業時間外の defer 登録の両方をスキップ。`completed` タスクの `in_review` への状態復帰は従来どおり行う（通知のみを止める）。
- `services/tasks.go`: 営業開始時に蓄積分を送る `CheckPendingReReviewNotifications` の送信ループでも同一ペアをスキップ（本変更前に蓄積済みの pending データへの防御）。pending フラグのクリアは従来どおり実行される。

比較対象は GitHub ログインではなく、最終的にメッセージへ渡るメンション文字列。Slack マッピングの結果として同一メンションに解決される場合もスキップ対象とする。

## テスト

- `handlers/webhook_test.go`: `TestHandleReviewRequestedEvent_SkipsWhenSenderEqualsReviewer` — sender==reviewer で通知が送られず、`completed` タスクは `in_review` に復帰することを検証。
- `services/pending_rereview_test.go`: `TestCheckPendingReReviewNotifications_SkipsSamePair` — 同一ペアは送らず異なるペアのみ送信、pending フラグはクリアされることを検証。

## 動作確認

- `go test ./handlers/ ./services/` → 両パッケージ OK
- 追加テスト2件とも PASS
- `go vet ./handlers/ ./services/` → 問題なし
