### PR TITLE
feat: 設定変更の確認メッセージをチャンネル全員に見えるようにする

### DIFF
--- a/handlers/away_modal.go
+++ b/handlers/away_modal.go
@@ -92,15 +92,22 @@ func handleAwayModalSubmission(c *gin.Context, db *gorm.DB, payload SlackActionP
 			})
 			return
 		}
-		if !services.IsTestMode && meta.UserID != "" {
-			var msg string
+		if !services.IsTestMode {
 			if res.RowsAffected == 0 {
-				msg = i18n.TWithLang(lang, "modal.away.nothing_deleted", form.SlackUserID)
+				// "nothing to delete" is operator feedback, not a change worth
+				// broadcasting — keep it ephemeral to avoid channel noise.
+				if meta.UserID != "" {
+					msg := i18n.TWithLang(lang, "modal.away.nothing_deleted", form.SlackUserID)
+					if err := services.PostEphemeral(meta.ChannelID, meta.UserID, msg); err != nil {
+						log.Printf("away nothing-deleted notice failed: %v", err)
+					}
+				}
 			} else {
-				msg = i18n.TWithLang(lang, "modal.away.deleted", form.SlackUserID)
-			}
-			if err := services.PostEphemeral(meta.ChannelID, meta.UserID, msg); err != nil {
-				log.Printf("away delete confirmation post failed: %v", err)
+				// An actual change: post visibly so teammates see the leave was cleared.
+				msg := i18n.TWithLang(lang, "modal.away.deleted", form.SlackUserID)
+				if err := services.PostChannelMessage(meta.ChannelID, msg); err != nil {
+					log.Printf("away delete confirmation post failed: %v", err)
+				}
 			}
 		}
 		c.Status(http.StatusOK)
@@ -154,9 +161,11 @@ func handleAwayModalSubmission(c *gin.Context, db *gorm.DB, payload SlackActionP
 		return
 	}
 
-	if !services.IsTestMode && meta.UserID != "" {
+	if !services.IsTestMode {
+		// Post visibly so teammates can see the leave was registered, not just
+		// the operator who opened the modal.
 		msg := i18n.TWithLang(lang, "modal.away.saved", form.SlackUserID)
-		if err := services.PostEphemeral(meta.ChannelID, meta.UserID, msg); err != nil {
+		if err := services.PostChannelMessage(meta.ChannelID, msg); err != nil {
 			log.Printf("away saved confirmation post failed: %v", err)
 		}
 	}

--- a/handlers/settings_modal.go
+++ b/handlers/settings_modal.go
@@ -200,9 +200,10 @@ func handleSettingsModalSubmission(c *gin.Context, db *gorm.DB, payload SlackAct
 				})
 				return
 			}
-			if !services.IsTestMode && meta.UserID != "" {
+			if !services.IsTestMode {
+				// Post visibly so the whole channel sees the config change.
 				msg := i18n.TWithLang(form.Language, "modal.deleted", form.LabelName)
-				if err := services.PostEphemeral(meta.ChannelID, meta.UserID, msg); err != nil {
+				if err := services.PostChannelMessage(meta.ChannelID, msg); err != nil {
 					log.Printf("settings deleted confirmation post failed: %v", err)
 				}
 			}
@@ -266,9 +267,10 @@ func handleSettingsModalSubmission(c *gin.Context, db *gorm.DB, payload SlackAct
 		}
 	}
 
-	if !services.IsTestMode && meta.UserID != "" {
+	if !services.IsTestMode {
+		// Post visibly so the whole channel sees the config change.
 		msg := i18n.TWithLang(form.Language, "modal.saved", form.LabelName)
-		if err := services.PostEphemeral(meta.ChannelID, meta.UserID, msg); err != nil {
+		if err := services.PostChannelMessage(meta.ChannelID, msg); err != nil {
 			log.Printf("settings saved confirmation post failed: %v", err)
 		}
 	}

--- a/handlers/user_mapping_modal.go
+++ b/handlers/user_mapping_modal.go
@@ -88,6 +88,8 @@ func handleUserMappingModalSubmission(c *gin.Context, db *gorm.DB, payload Slack
 		var existing models.UserMapping
 		res := db.Where("github_username = ?", form.GithubUsername).First(&existing)
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			// "nothing to delete" is operator feedback, not a change worth
+			// broadcasting — keep it ephemeral to avoid channel noise.
 			if !services.IsTestMode && meta.UserID != "" {
 				msg := i18n.TWithLang(lang, "modal.user_mapping.delete_not_found", form.GithubUsername)
 				if err := services.PostEphemeral(meta.ChannelID, meta.UserID, msg); err != nil {
@@ -115,9 +117,10 @@ func handleUserMappingModalSubmission(c *gin.Context, db *gorm.DB, payload Slack
 			})
 			return
 		}
-		if !services.IsTestMode && meta.UserID != "" {
+		if !services.IsTestMode {
+			// Post visibly so the whole channel sees the mapping change.
 			msg := i18n.TWithLang(lang, "modal.user_mapping.deleted", form.GithubUsername)
-			if err := services.PostEphemeral(meta.ChannelID, meta.UserID, msg); err != nil {
+			if err := services.PostChannelMessage(meta.ChannelID, msg); err != nil {
 				log.Printf("user-mapping deleted notice failed: %v", err)
 			}
 		}
@@ -165,9 +168,10 @@ func handleUserMappingModalSubmission(c *gin.Context, db *gorm.DB, payload Slack
 		return
 	}
 
-	if !services.IsTestMode && meta.UserID != "" {
+	if !services.IsTestMode {
+		// Post visibly so the whole channel sees the mapping change.
 		msg := i18n.TWithLang(lang, "modal.user_mapping.saved", form.GithubUsername)
-		if err := services.PostEphemeral(meta.ChannelID, meta.UserID, msg); err != nil {
+		if err := services.PostChannelMessage(meta.ChannelID, msg); err != nil {
 			log.Printf("user-mapping saved notice failed: %v", err)
 		}
 	}

--- a/services/away_modal_test.go
+++ b/services/away_modal_test.go
@@ -50,8 +50,9 @@ func TestBuildAwayManagementModalView_HasAllFields(t *testing.T) {
 }
 
 // TestBuildAwayManagementModalView_PrivateMetadata: channel ID and user ID
-// must round-trip through private_metadata so the submission handler can
-// post an ephemeral confirmation back into the same channel.
+// must round-trip through private_metadata so the submission handler can post
+// the confirmation back into the same channel — a visible channel message for
+// an actual change, or an ephemeral notice (to the user) when nothing changed.
 func TestBuildAwayManagementModalView_PrivateMetadata(t *testing.T) {
 	view := BuildAwayManagementModalView(AwayManagementModalInputs{
 		ChannelID: "C12345",

--- a/services/slack.go
+++ b/services/slack.go
@@ -646,6 +646,50 @@ func PostEphemeral(channel, user, message string) error {
 	return nil
 }
 
+// PostChannelMessage posts a plain message to the channel, visible to everyone
+// (not a thread reply, not ephemeral). Used for settings-change confirmations
+// that are worth surfacing to the whole channel — e.g. "so-and-so's leave was
+// saved" — so teammates can see the change rather than only the operator.
+// Returns nil immediately in test mode.
+func PostChannelMessage(channel, message string) error {
+	if IsTestMode {
+		log.Printf("test mode: would post channel message to channel=%s", channel)
+		return nil
+	}
+
+	body := map[string]any{
+		"channel": channel,
+		"text":    message,
+	}
+
+	jsonData, _ := json.Marshal(body)
+	req, err := http.NewRequest("POST", SlackAPIBaseURL()+"/chat.postMessage", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+os.Getenv("SLACK_BOT_TOKEN"))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBytes, _ := io.ReadAll(resp.Body)
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(respBytes, &result); err != nil {
+		return fmt.Errorf("slack API response parse error: %v (body: %s)", err, string(respBytes))
+	}
+	if !result.OK {
+		return fmt.Errorf("slack chat.postMessage error: %s", result.Error)
+	}
+	return nil
+}
+
 // PostToThreadWithButtons posts a message with buttons to a thread
 func PostToThreadWithButtons(channel, ts, message string, taskID, lang string) error {
 	t := i18n.L(lang)

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -125,6 +125,71 @@ func TestPostToThread(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Not all mocks were used")
 }
 
+// TestPostChannelMessage: settings-change confirmations (leave saved, config
+// deleted, ...) must be visible to everyone in the channel, not only the
+// operator. So this posts a plain channel message via chat.postMessage with
+// just channel + text — no thread_ts (would bury it in a thread) and no user
+// (would make it ephemeral). The exact-body match pins that contract.
+func TestPostChannelMessage(t *testing.T) {
+	// IsTestMode is a package-global toggled by other tests; force it off here so
+	// the real HTTP path (mocked by gock) actually runs, regardless of order.
+	originalTestMode := IsTestMode
+	IsTestMode = false
+	defer func() { IsTestMode = originalTestMode }()
+
+	originalToken := os.Getenv("SLACK_BOT_TOKEN")
+	defer func() {
+		_ = os.Setenv("SLACK_BOT_TOKEN", originalToken)
+	}()
+	_ = os.Setenv("SLACK_BOT_TOKEN", "test-token")
+
+	defer gock.Off()
+
+	// Success: posts to chat.postMessage with exactly {channel, text}.
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		MatchHeader("Authorization", "Bearer test-token").
+		MatchHeader("Content-Type", "application/json").
+		JSON(map[string]interface{}{
+			"channel": "C12345",
+			"text":    "<@U999> の休暇を保存しました 🌴",
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{"ok": true})
+
+	err := PostChannelMessage("C12345", "<@U999> の休暇を保存しました 🌴")
+	assert.NoError(t, err)
+	assert.True(t, gock.IsDone(), "Not all mocks were used")
+
+	// Error: Slack returns ok:false → surfaced as an error.
+	gock.New("https://slack.com").
+		Post("/api/chat.postMessage").
+		Reply(200).
+		JSON(map[string]interface{}{
+			"ok":    false,
+			"error": "channel_not_found",
+		})
+
+	err = PostChannelMessage("INVALID", "message")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "channel_not_found")
+	assert.True(t, gock.IsDone(), "Not all mocks were used")
+}
+
+// TestPostChannelMessage_TestMode: in test mode no network call is made and the
+// function returns nil, mirroring PostEphemeral's behavior.
+func TestPostChannelMessage_TestMode(t *testing.T) {
+	IsTestMode = true
+	defer func() { IsTestMode = false }()
+
+	defer gock.Off()
+	// No mock registered: if a request were made, gock would error out.
+
+	err := PostChannelMessage("C12345", "message")
+	assert.NoError(t, err)
+	assert.False(t, gock.HasUnmatchedRequest(), "no HTTP request should be made in test mode")
+}
+
 func TestIsChannelArchived(t *testing.T) {
 	// Save environment variables before test and restore after
 	originalToken := os.Getenv("SLACK_BOT_TOKEN")


### PR DESCRIPTION
## 背景 / なぜ

モーダルから設定変更を行った際の確認メッセージ（例: `@xxx の休暇を保存しました 🌴`）が **ephemeral（「あなただけに表示されています」）** で、操作した本人にしか見えていませんでした。

しかし、休暇管理をはじめとする設定変更は「誰かが休暇に入る」「ラベルの設定が変わった」といった、チームメンバー全員が知って得をする情報です。本人だけに見えるより、チャンネル全員に見える方がメリットがあります。

## 変更内容

モーダル経由の設定変更（休暇管理 / チャンネル設定 / ユーザーマッピング）の **保存・削除の確認メッセージを、チャンネル全員に見える通常メッセージ**（`chat.postMessage`）に変更しました。

- サービス層に `PostChannelMessage(channel, message)` を追加（スレッド返信でもephemeralでもない、チャンネル本体への通常投稿）
- 3つのモーダルハンドラーの「保存しました」「削除しました」を `PostEphemeral` → `PostChannelMessage` に置き換え

### ephemeral のまま残したもの

「削除対象がありませんでした」「マッピングが見つかりませんでした」といった **"変更なし" の通知** は、変更ではなく操作者へのフィードバックにすぎず、全員に流すと単なるノイズになるため、これまで通り操作者だけへの ephemeral のままにしています。

## スコープ外（今回は対象外）

スラッシュコマンドの応答（`/slack-review-notify` の help や reviews 一覧、set-away 等）はモーダルとは別の仕組み（Slack の `response_type`）で、今回のトリガーである `休暇を保存しました` モーダルとは経路が異なるため対象外としています。こちらも公開したい場合は別途対応できます。

## テスト

- `PostChannelMessage` の単体テストを追加（`chat.postMessage` に `{channel, text}` のみ・スレッドやephemeralにならないことを厳密に検証、エラー時・テストモード時の挙動も確認）
- `go test ./...` / `go vet ./...` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)